### PR TITLE
Update NS version requirements in contributing doc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ Refer to the [nativescript-vue/nativescript-vue.org repository](https://github.c
 
 You will need Node.js installed, as well as NativeScript.
 
-Please make sure you are using Nativescript 3.x
+Please make sure you are using Nativescript 4.x
 
 After cloning the repo, run:
 


### PR DESCRIPTION
The current 1.4.0-alpha.X version is not working with NS 3.x anymore, so the contributing doc should not mention that version.