### PR TITLE
Allow debugging the app in chrome devtools while testing.

### DIFF
--- a/build/sample-runner.js
+++ b/build/sample-runner.js
@@ -40,7 +40,7 @@ inquirer
   })
 
 function runPlatform(platform) {
-  tns = spawn('tns', ['run', platform], {
+  tns = spawn('tns', ['debug', platform], {
     cwd: path.resolve(__dirname, '../samples')
   })
 


### PR DESCRIPTION
Change `tns run ...` to `tns debug ...` which allows developer to debug the sample app in the chrome devtools 