### PR TITLE
Frame and Router fixes for 4.1+

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ and these awesome backers:
 - Andy Drexler
 - ChiwalahSoftware
 - Nayir Chami
+- Teon Ooi
 
 If you'd like to join them, please consider [becoming a backer / sponsor on Patreon](https://www.patreon.com/rigor789).
 

--- a/build/config.js
+++ b/build/config.js
@@ -78,11 +78,6 @@ const genConfig = (name) => {
                 'process.env.NS_VUE_VERSION': `'${NSVueVersion}'`
             }),
             flow(),
-            buble({
-              transforms: {
-                dangerousForOf: true
-              }
-            }),
             alias(aliases),
             resolve(),
             commonjs(),

--- a/build/config.js
+++ b/build/config.js
@@ -65,6 +65,9 @@ const genConfig = (name) => {
         treeshake: {
             pureExternalModules: id => id.startsWith('weex')
         },
+        watch: {
+          chokidar: false
+        },
         plugins: [
             replace({
                 __WEEX__: false,

--- a/build/config.js
+++ b/build/config.js
@@ -1,7 +1,6 @@
 const alias = require('rollup-plugin-alias')
 const commonjs = require('rollup-plugin-commonjs')
 const resolve = require('rollup-plugin-node-resolve')
-const buble = require('rollup-plugin-buble')
 const replace = require('rollup-plugin-replace')
 const flow = require('rollup-plugin-flow-no-whitespace')
 const path = require('path')

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "jest",
     "tdd": "jest --watch",
     "samples": "node build/sample-runner.js",
-    "dev": "rollup -c build/config.js -w --o samples/app/nativescript-vue.js --environment TARGET:nativescript-vue",
+    "dev": "rollup -c build/config.js -w --o dist/index.js --environment TARGET:nativescript-vue",
     "build": "node build/build.js",
     "build:docs": "cd docs && npm run build",
     "prettier": "prettier --no-semi --single-quote --write \"{{platform,__test__}/**/*.js,samples/app/*.js}\"",
@@ -37,8 +37,8 @@
   "homepage": "https://github.com/rigor789/nativescript-vue#readme",
   "nativescript": {
     "platforms": {
-      "android": "3.4.0",
-      "ios": "3.4.0"
+      "android": "4.1.2",
+      "ios": "4.1.0"
     },
     "plugin": {
       "vue": "true",
@@ -64,18 +64,18 @@
     "jest-junit": "^3.5.0",
     "lint-staged": "^6.1.0",
     "prettier": "^1.10.2",
-    "rollup": "^0.55.3",
+    "rollup": "^0.62.0",
     "rollup-plugin-alias": "^1.4.0",
-    "rollup-plugin-buble": "^0.18.0",
-    "rollup-plugin-commonjs": "^8.3.0",
+    "rollup-plugin-buble": "^0.19.2",
+    "rollup-plugin-commonjs": "^9.1.3",
     "rollup-plugin-flow-no-whitespace": "^1.0.0",
-    "rollup-plugin-node-resolve": "^3.0.2",
+    "rollup-plugin-node-resolve": "^3.3.0",
     "rollup-plugin-replace": "^2.0.0",
     "rollup-plugin-resolve-aliases": "^0.2.0",
     "rollup-watch": "^4.3.1",
     "semver": "^5.5.0",
     "set-value": "^2.0.0",
-    "tns-core-modules": "4.0.0",
+    "tns-core-modules": "4.1.0",
     "util-inspect": "^0.1.8",
     "vue": "^2.5.16"
   },

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "jest",
     "tdd": "jest --watch",
     "samples": "node build/sample-runner.js",
-    "dev": "rollup -c build/config.js -w --o ./../car-rental/app/nativescript-vue.js --environment TARGET:nativescript-vue",
+    "dev": "rollup -c build/config.js -w --o dist/index.js --environment TARGET:nativescript-vue",
     "build": "node build/build.js",
     "build:docs": "cd docs && npm run build",
     "prettier": "prettier --no-semi --single-quote --write \"{{platform,__test__}/**/*.js,samples/app/*.js}\"",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
     "prettier": "^1.10.2",
     "rollup": "^0.62.0",
     "rollup-plugin-alias": "^1.4.0",
-    "rollup-plugin-buble": "^0.19.2",
     "rollup-plugin-commonjs": "^9.1.3",
     "rollup-plugin-flow-no-whitespace": "^1.0.0",
     "rollup-plugin-node-resolve": "^3.3.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "jest",
     "tdd": "jest --watch",
     "samples": "node build/sample-runner.js",
-    "dev": "rollup -c build/config.js -w --o dist/index.js --environment TARGET:nativescript-vue",
+    "dev": "rollup -c build/config.js -w --o ./../car-rental/app/nativescript-vue.js --environment TARGET:nativescript-vue",
     "build": "node build/build.js",
     "build:docs": "cd docs && npm run build",
     "prettier": "prettier --no-semi --single-quote --write \"{{platform,__test__}/**/*.js,samples/app/*.js}\"",

--- a/platform/nativescript/element-registry.js
+++ b/platform/nativescript/element-registry.js
@@ -1,6 +1,8 @@
 import * as builtInComponents from './runtime/components'
 
 const elementMap = new Map()
+const nativeRegExp = /Native/gi
+const dashRegExp = /-/g
 
 const defaultViewMeta = {
   skipAddToDom: false,
@@ -13,8 +15,8 @@ const defaultViewMeta = {
 
 export function normalizeElementName(elementName) {
   return `native${elementName
-    .replace(/Native/gi, '')
-    .replace(/-/g, '')
+    .replace(nativeRegExp, '')
+    .replace(dashRegExp, '')
     .toLowerCase()}`
 }
 

--- a/platform/nativescript/framework.js
+++ b/platform/nativescript/framework.js
@@ -21,16 +21,18 @@ Vue.use(ModalPlugin)
 Vue.use(NavigatorPlugin)
 Vue.use(RouterPlugin)
 
+const newLineRegExp = /\\n/g
+
 console.log = (function(log, inspect, Vue) {
-  return function() {
-    return log.apply(
+  return function(...args) {
+    return log.call(
       this,
-      Array.prototype.map.call(arguments, function(arg) {
+      ...Array.prototype.map.call(args, function(arg) {
         return inspect(arg, {
           depth: 2,
           colors: Vue.config.debug,
           showHidden: true
-        }).replace(/\\n/g, '\n')
+        }).replace(newLineRegExp, '\n')
       })
     )
   }

--- a/platform/nativescript/framework.js
+++ b/platform/nativescript/framework.js
@@ -9,7 +9,7 @@ import application from 'tns-core-modules/application'
 import Vue from './runtime/index'
 import ModalPlugin from './plugins/modal-plugin'
 import NavigatorPlugin from './plugins/navigator-plugin'
-// import RouterPlugin from './plugins/router-plugin'
+import RouterPlugin from './plugins/router-plugin'
 
 import { setVue } from './util'
 
@@ -19,7 +19,7 @@ setVue(Vue)
 
 Vue.use(ModalPlugin)
 Vue.use(NavigatorPlugin)
-// Vue.use(RouterPlugin)
+Vue.use(RouterPlugin)
 
 console.log = (function(log, inspect, Vue) {
   return function() {

--- a/platform/nativescript/plugins/router-plugin.js
+++ b/platform/nativescript/plugins/router-plugin.js
@@ -13,53 +13,51 @@ class NativeScriptHistory {
     this._Vue = VueInstance
 
     if (android) {
-      android.on("activityBackPressed", function(args) {
+      android.on('activityBackPressed', function(args) {
         if (history.index > 0) {
           args.cancel = true
 
           router.back()
         }
-      });
+      })
     }
 
-    properties.forEach((name) => {
+    properties.forEach(name => {
       Object.defineProperty(NativeScriptHistory.prototype, name, {
         get: () => {
           return this.history[name]
         },
-        set: (value) => {
+        set: value => {
           this.history[name] = value
         }
       })
     })
   }
 
-  static _buildEntry(args) {
-    let entry;
+  _buildEntry(args) {
+    let entry
 
     for (let i = 1; i < args.length; i++) {
       if (isPlainObject(args[i])) {
-        entry = args[i];
-        delete args[i];
+        entry = args[i]
+        delete args[i]
       }
     }
 
-    return { args, entry };
+    return { args, entry }
   }
 
   push(...args) {
-    this.isGoingBack = false;
+    ({ args, entry: this.currentEntry } = this._buildEntry(args))
 
-    ({ args, entry: this.currentEntry } = NativeScriptHistory._buildEntry(args))
-
+    this.isGoingBack = false
     this.history.push.call(this.history, ...args)
   }
 
   replace(...args) {
-    this.isGoingBack = false;
+    ({ args, entry: this.currentEntry } = this._buildEntry(args))
 
-    ({ args, entry: this.currentEntry } = NativeScriptHistory._buildEntry(args))
-
+    this.isGoingBack = false
     this.history.replace.call(this.history, ...args)
   }
 
@@ -113,26 +111,25 @@ export function patchDefaultRouter(router, Vue) {
 
   router.history = new NativeScriptHistory(router, router.history, Vue)
 
-  router.push = function push (...args) {
-    this.history.push(...args);
-  };
+  router.push = function push(...args) {
+    this.history.push(...args)
+  }
 
-  router.replace = function push (...args) {
-    this.history.push(...args);
-  };
+  router.replace = function push(...args) {
+    this.history.push(...args)
+  }
 
-  router.go = function go (n, entry) {
-    this.history.go(n, entry);
-  };
+  router.go = function go(n, entry) {
+    this.history.go(n, entry)
+  }
 
-  router.back = function back (entry) {
-    this.go(-1, entry);
-  };
+  router.back = function back(entry) {
+    this.go(-1, entry)
+  }
 
-  router.forward = function forward (entry) {
-    this.go(1, entry);
-  };
-
+  router.forward = function forward(entry) {
+    this.go(1, entry)
+  }
 }
 
 //export function patchRouter(router, Vue) {

--- a/platform/nativescript/plugins/router-plugin.js
+++ b/platform/nativescript/plugins/router-plugin.js
@@ -1,132 +1,8 @@
 import { before } from '../util/index'
 import { Page } from 'tns-core-modules/ui/page'
-//import { android } from 'tns-core-modules/application'
+import { android } from 'tns-core-modules/application'
 
 const properties = ['stack', 'index', 'current']
-
-var View = {
-  name: 'router-view',
-  functional: true,
-  props: {
-    name: {
-      type: String,
-      default: 'default'
-    }
-  },
-//  render: function render (_, ref) {
-//    const props = ref.props;
-//    const children = ref.children;
-//    const data = ref.data;
-//
-//    let parent = ref.parent;
-//
-//    debugger;
-//
-//    data.routerView = true;
-//
-//    // directly use parent context's createElement() function
-//    // so that components rendered by router-view can resolve named slots
-//    const h = parent.$createElement;
-//    const name = props.name;
-//    const route = parent.$route;
-//    const cache = parent._routerViewCache || (parent._routerViewCache = {});
-//
-//    // determine current view depth, also check to see if the tree
-//    // has been toggled inactive but kept-alive.
-//    let depth = 0;
-//    let inactive = false;
-//
-//    while (parent && parent._routerRoot !== parent) {
-//      if (parent.$vnode && parent.$vnode.data.routerView) {
-//        depth++;
-//      }
-//      if (parent._inactive) {
-//        inactive = true;
-//      }
-//      parent = parent.$parent;
-//    }
-//    data.routerViewDepth = depth;
-//
-//    // render previous view if the tree is inactive and kept-alive
-//    if (inactive) {
-//      return h(cache[name], data, children)
-//    }
-//
-//    const matched = route.matched[depth];
-//    // render empty node if no matched route
-//    if (!matched) {
-//      cache[name] = null;
-//      return h()
-//    }
-//
-//    const component = cache[name] = matched.components[name];
-//
-//    // attach instance registration hook
-//    // this will be called in the instance's injected lifecycle hooks
-//    data.registerRouteInstance = function (vm, val) {
-//      // val could be undefined for unregistration
-//      const current = matched.instances[name];
-//      if (
-//        (val && current !== vm) ||
-//        (!val && current === vm)
-//      ) {
-//        matched.instances[name] = val;
-//      }
-//    }
-//
-//    // also register instance in prepatch hook
-//    // in case the same component instance is reused across different routes
-//    ;(data.hook || (data.hook = {})).prepatch = function (_, vnode) {
-//      matched.instances[name] = vnode.componentInstance;
-//    };
-//
-//    // resolve props
-//    var propsToPass = data.props = resolveProps(route, matched.props && matched.props[name]);
-//    if (propsToPass) {
-//      // clone to prevent mutation
-//      propsToPass = data.props = extend({}, propsToPass);
-//      // pass non-declared props as attrs
-//      var attrs = data.attrs = data.attrs || {};
-//      for (var key in propsToPass) {
-//        if (!component.props || !(key in component.props)) {
-//          attrs[key] = propsToPass[key];
-//          delete propsToPass[key];
-//        }
-//      }
-//    }
-//
-//    const rendered = h(component, data, children);
-//
-//    //setTimeout(() => {
-//    //  debugger;
-//    //  if (rendered.context.$el) {
-//    //    parent.$navigateTo(component, { frame: rendered.context.$el._nativeView.id });
-//    //  }
-//    //});
-//    //
-//    return rendered;
-//  }
-};
-//
-//function resolveProps (route, config) {
-//  switch (typeof config) {
-//    case 'undefined':
-//      return
-//    case 'object':
-//      return config
-//    case 'function':
-//      return config(route)
-//    case 'boolean':
-//      return config ? route.params : undefined
-//    default:
-//      if (process.env.NODE_ENV !== 'production') {
-//        console.log(
-//          "props in \"" + (route.path) + "\" is a " + (typeof config) + ", " +
-//          "expecting an object, function or boolean."
-//        );
-//      }
-//  }
-//}
 
 const NativeScriptHistory = (function () {
   let Vue;
@@ -136,38 +12,11 @@ const NativeScriptHistory = (function () {
     this.history = history;
     Vue = VueInstance;
 
-    const routerView = Vue.options.components["router-view"];
+    android.on("activityBackPressed", function (args) {
+     args.cancel = true;
 
-    if (routerView && routerView.options.render) {
-      const originalRender = routerView.options.render;
-
-      View.render = function render (createElement, context) {
-        const result = originalRender.call(this, createElement, context)
-        const originalRegister = result.data.registerRouteInstance;
-
-        result.data.registerRouteInstance = function (vm, val) {
-          originalRegister.call(this, vm, val)
-
-          vm.$nextTick(() => {
-            vm.$parent.navigate({
-              create: () => vm.$el.nativeView
-            })
-          });
-        }
-
-        return result;
-      }
-    }
-
-    Vue.delete(Vue.options.components, "router-view");
-
-    Vue.component('router-view', View);
-
-    //android.on("activityBackPressed", function (args) {
-    //  args.cancel = true;
-    //
-    //  router.back();
-    //});
+     router.back();
+    });
 
     properties.forEach((name) => {
       Object.defineProperty(NativeScriptHistory.prototype, name, {

--- a/platform/nativescript/plugins/router-plugin.js
+++ b/platform/nativescript/plugins/router-plugin.js
@@ -12,11 +12,15 @@ class NativeScriptHistory {
     this.isGoingBack = false
     this._Vue = VueInstance
 
-    android.on("activityBackPressed", function (args) {
-     args.cancel = true
+    if (android) {
+      android.on("activityBackPressed", function(args) {
+        if (history.index > 0) {
+          args.cancel = true
 
-     router.back()
-    });
+          router.back()
+        }
+      });
+    }
 
     properties.forEach((name) => {
       Object.defineProperty(NativeScriptHistory.prototype, name, {

--- a/platform/nativescript/plugins/router-plugin.js
+++ b/platform/nativescript/plugins/router-plugin.js
@@ -1,5 +1,5 @@
-import { before } from '../util/index'
-import { Page } from 'tns-core-modules/ui/page'
+//import { before } from '../util/index'
+//import { Page } from 'tns-core-modules/ui/page'
 import { android } from 'tns-core-modules/application'
 
 const properties = ['stack', 'index', 'current']
@@ -8,14 +8,15 @@ const NativeScriptHistory = (function () {
   let Vue;
 
   function NativeScriptHistory (router, history, VueInstance) {
-    this.router = router;
-    this.history = history;
-    Vue = VueInstance;
+    this.router = router
+    this.history = history
+    this.isGoingBack = false
+    Vue = VueInstance
 
     android.on("activityBackPressed", function (args) {
-     args.cancel = true;
+     args.cancel = true
 
-     router.back();
+     router.back()
     });
 
     properties.forEach((name) => {
@@ -26,59 +27,65 @@ const NativeScriptHistory = (function () {
         set: (value) => {
           this.history[name] = value
         }
-      });
-    });
+      })
+    })
   }
 
-  NativeScriptHistory.prototype.push = function push (location, onComplete, onAbort) {
+  NativeScriptHistory.prototype.push = function push(location, onComplete, onAbort) {
+    this.isGoingBack = false;
+
     this.history.push.call(this.history, location, (route) => {
-      onComplete && onComplete(route);
-    }, onAbort);
+      onComplete && onComplete(route)
+    }, onAbort)
   };
 
-  NativeScriptHistory.prototype.replace = function replace (location, onComplete, onAbort) {
+  NativeScriptHistory.prototype.replace = function replace(location, onComplete, onAbort) {
+    this.isGoingBack = false;
+
     this.history.replace.call(this.history, location, (route) => {
-      onComplete && onComplete(route);
-    }, onAbort);
+      onComplete && onComplete(route)
+    }, onAbort)
   };
 
-  NativeScriptHistory.prototype.go = function go (n) {
-    this.history.go.call(this.history, n);
+  NativeScriptHistory.prototype.go = function go(n) {
+    this.isGoingBack = n < 0
+
+    this.history.go.call(this.history, n)
   };
 
-  NativeScriptHistory.prototype.getCurrentLocation = function getCurrentLocation () {
+  NativeScriptHistory.prototype.getCurrentLocation = function getCurrentLocation() {
     return this.history.getCurrentLocation.call(this.history)
   };
 
-  NativeScriptHistory.prototype.onReady = function onReady (...args) {
+  NativeScriptHistory.prototype.onReady = function onReady(...args) {
     this.history.onReady.call(this.history, ...args)
   }
 
-  NativeScriptHistory.prototype.onError = function onError (...args) {
+  NativeScriptHistory.prototype.onError = function onError(...args) {
     this.history.onError.call(this.history, ...args)
   }
 
-  NativeScriptHistory.prototype.listen = function listen (...args) {
+  NativeScriptHistory.prototype.listen = function listen(...args) {
     this.history.listen.call(this.history, ...args)
   }
 
-  NativeScriptHistory.prototype.transitionTo = function transitionTo (...args) {
+  NativeScriptHistory.prototype.transitionTo = function transitionTo(...args) {
     this.history.transitionTo.call(this.history, ...args)
   }
 
-  NativeScriptHistory.prototype.confirmTransition = function confirmTransition (...args) {
+  NativeScriptHistory.prototype.confirmTransition = function confirmTransition(...args) {
     this.history.confirmTransition.call(this.history, ...args)
   }
 
-  NativeScriptHistory.prototype.updateRoute = function updateRoute (...args) {
+  NativeScriptHistory.prototype.updateRoute = function updateRoute(...args) {
     this.history.updateRoute.call(this.history, ...args)
   }
 
-  NativeScriptHistory.prototype.setupListeners = function setupListeners (...args) {
+  NativeScriptHistory.prototype.setupListeners = function setupListeners(...args) {
     this.history.setupListeners.call(this.history, ...args)
   }
 
-  return NativeScriptHistory;
+  return NativeScriptHistory
 }());
 
 
@@ -89,106 +96,106 @@ export function patchDefaultRouter(router, Vue) {
 
   router.__patched_for_routing__ = true
 
-  router.history = new NativeScriptHistory(router, router.history, Vue);
+  router.history = new NativeScriptHistory(router, router.history, Vue)
 }
 
-export function patchRouter(router, Vue) {
-  if (router.__patched_for_page_routing__) {
-    return
-  }
-  router.__patched_for_page_routing__ = true
-
-  // The problem: When using router.replace() to set the initial route
-  // the history index stays -1, which then causes an issue when visiting a route,
-  // going back, and then trying to visit again (the active route is not changed on nav back)
-  // This fixes it, since it allows the router.go logic to run
-  router.history.index = 0
-
-  // initial navigation states
-  router.isBackNavigation = false
-  router.shouldNavigate = true
-  router.pageStack = []
-  router.pageTransition = null
-
-  router.setPageTransition = (transition, duration, curve) => {
-    if (typeof transition === 'string') {
-      return (router.pageTransition = {
-        name: transition,
-        duration,
-        curve
-      })
-    }
-
-    router.pageTransition = transition
-  }
-
-  router._beginBackNavigation = (shouldNavigate = true) => {
-    if (router.isBackNavigation) {
-      throw new Error(
-        'router._beginBackNavigation was called while already navigating back.'
-      )
-    }
-
-    router.isBackNavigation = true
-    router.shouldNavigate = shouldNavigate
-  }
-
-  router._finishBackNavigation = () => {
-    if (!router.isBackNavigation) {
-      throw new Error(
-        'router._finishBackNavigation was called while there was no back navigation.'
-      )
-    }
-
-    router.isBackNavigation = false
-  }
-
-  router.go = before(router.go, router, n => {
-    if (n === -1 && !router.isBackNavigation) {
-      router._beginBackNavigation()
-    }
-  })
-
-  router.afterEach(() => {
-    if (router.isBackNavigation) {
-      if (router.shouldNavigate) {
-        Vue.navigateBack()
-      }
-      router.pageStack.pop()
-      const page = router.pageStack[router.pageStack.length - 1]
-
-      const callback = ({ isBackNavigation }) => {
-        if (isBackNavigation) {
-          router._finishBackNavigation()
-        }
-        page.off(Page.navigatedToEvent, callback)
-      }
-
-      page.on(Page.navigatedToEvent, callback)
-
-      return
-    }
-
-    const component = router.getMatchedComponents()[0]
-
-    router.app
-      .$navigateTo(component, {
-        context: { router },
-        transition: router.pageTransition
-        // Todo: add transitionAndroid and transitionIOS
-      })
-      .then(page => {
-        router.pageStack.push(page)
-
-        page.on(Page.navigatedFromEvent, ({ isBackNavigation }) => {
-          if (isBackNavigation && !router.isBackNavigation) {
-            router._beginBackNavigation(false)
-            router.back()
-          }
-        })
-      })
-  })
-}
+//export function patchRouter(router, Vue) {
+//  if (router.__patched_for_page_routing__) {
+//    return
+//  }
+//  router.__patched_for_page_routing__ = true
+//
+//  // The problem: When using router.replace() to set the initial route
+//  // the history index stays -1, which then causes an issue when visiting a route,
+//  // going back, and then trying to visit again (the active route is not changed on nav back)
+//  // This fixes it, since it allows the router.go logic to run
+//  router.history.index = 0
+//
+//  // initial navigation states
+//  router.isBackNavigation = false
+//  router.shouldNavigate = true
+//  router.pageStack = []
+//  router.pageTransition = null
+//
+//  router.setPageTransition = (transition, duration, curve) => {
+//    if (typeof transition === 'string') {
+//      return (router.pageTransition = {
+//        name: transition,
+//        duration,
+//        curve
+//      })
+//    }
+//
+//    router.pageTransition = transition
+//  }
+//
+//  router._beginBackNavigation = (shouldNavigate = true) => {
+//    if (router.isBackNavigation) {
+//      throw new Error(
+//        'router._beginBackNavigation was called while already navigating back.'
+//      )
+//    }
+//
+//    router.isBackNavigation = true
+//    router.shouldNavigate = shouldNavigate
+//  }
+//
+//  router._finishBackNavigation = () => {
+//    if (!router.isBackNavigation) {
+//      throw new Error(
+//        'router._finishBackNavigation was called while there was no back navigation.'
+//      )
+//    }
+//
+//    router.isBackNavigation = false
+//  }
+//
+//  router.go = before(router.go, router, n => {
+//    if (n === -1 && !router.isBackNavigation) {
+//      router._beginBackNavigation()
+//    }
+//  })
+//
+//  router.afterEach(() => {
+//    if (router.isBackNavigation) {
+//      if (router.shouldNavigate) {
+//        Vue.navigateBack()
+//      }
+//      router.pageStack.pop()
+//      const page = router.pageStack[router.pageStack.length - 1]
+//
+//      const callback = ({ isBackNavigation }) => {
+//        if (isBackNavigation) {
+//          router._finishBackNavigation()
+//        }
+//        page.off(Page.navigatedToEvent, callback)
+//      }
+//
+//      page.on(Page.navigatedToEvent, callback)
+//
+//      return
+//    }
+//
+//    const component = router.getMatchedComponents()[0]
+//
+//    router.app
+//      .$navigateTo(component, {
+//        context: { router },
+//        transition: router.pageTransition
+//        // Todo: add transitionAndroid and transitionIOS
+//      })
+//      .then(page => {
+//        router.pageStack.push(page)
+//
+//        page.on(Page.navigatedFromEvent, ({ isBackNavigation }) => {
+//          if (isBackNavigation && !router.isBackNavigation) {
+//            router._beginBackNavigation(false)
+//            router.back()
+//          }
+//        })
+//      })
+//  })
+//}
 
 export default {
   install(Vue) {
@@ -200,40 +207,40 @@ export default {
         }
 
         const router = this.$options.router
-        const isPageRouting = router.options.pageRouting
-        const self = this
+        //const isPageRouting = router.options.pageRouting
+        //const self = this
 
-        if (isPageRouting) {
-          patchRouter(router, Vue)
-        } else {
+        //if (isPageRouting) {
+        //  patchRouter(router, Vue)
+        //} else {
           patchDefaultRouter(router, Vue)
 
-          return
-        }
-
-        // Overwrite the default $start function
-        this.$start = () => {
-          this.__is_root__ = true
-          this.__started__ = true // skips the default start procedure
-          this.$options.render = () => {} // removes warning for no render / template
-
-          // Mount the root component
-          const placeholder = Vue.$document.createComment('placeholder')
-          self.$mount(placeholder)
-
-          const initial = router.getMatchedComponents()[0]
-
-          this.$navigateTo(
-            initial,
-            {
-              context: { router },
-              clearHistory: true
-            },
-            page => {
-              router.pageStack.push(page)
-            }
-          )
-        }
+        //  return
+        //}
+        //
+        //// Overwrite the default $start function
+        //this.$start = () => {
+        //  this.__is_root__ = true
+        //  this.__started__ = true // skips the default start procedure
+        //  this.$options.render = () => {} // removes warning for no render / template
+        //
+        //  // Mount the root component
+        //  const placeholder = Vue.$document.createComment('placeholder')
+        //  self.$mount(placeholder)
+        //
+        //  const initial = router.getMatchedComponents()[0]
+        //
+        //  this.$navigateTo(
+        //    initial,
+        //    {
+        //      context: { router },
+        //      clearHistory: true
+        //    },
+        //    page => {
+        //      router.pageStack.push(page)
+        //    }
+        //  )
+        //}
       }
     })
   }

--- a/platform/nativescript/renderer/ViewNode.js
+++ b/platform/nativescript/renderer/ViewNode.js
@@ -95,28 +95,26 @@ export default class ViewNode {
 
   /* istanbul ignore next */
   setAttribute(key, value) {
+    const nv = this.nativeView
+
     try {
       if (XML_ATTRIBUTES.indexOf(key) !== -1) {
-        this.nativeView[key] = value
+        nv[key] = value
       } else {
         // detect expandable attrs for boolean values
         // See https://vuejs.org/v2/guide/components-props.html#Passing-a-Boolean
-        if (types.isBoolean(this.nativeView[key]) && value === '') {
+        if (types.isBoolean(nv[key]) && value === '') {
           value = true
         }
 
         if (isAndroid && key.startsWith('android:')) {
-          set(this.nativeView, key.substr(8), value)
+          set(nv, key.substr(8), value)
         } else if (isIOS && key.startsWith('ios:')) {
-          set(this.nativeView, key.substr(4), value)
+          set(nv, key.substr(4), value)
         } else if (key.endsWith('.decode')) {
-          set(
-            this.nativeView,
-            key.slice(0, -7),
-            XmlParser._dereferenceEntities(value)
-          )
+          set(nv, key.slice(0, -7), XmlParser._dereferenceEntities(value))
         } else {
-          set(this.nativeView, key, value)
+          set(nv, key, value)
         }
       }
     } catch (e) {

--- a/platform/nativescript/renderer/ViewNode.js
+++ b/platform/nativescript/renderer/ViewNode.js
@@ -4,6 +4,7 @@ import { getViewMeta, normalizeElementName } from '../element-registry'
 import * as viewUtil from './utils'
 import { isAndroid, isIOS } from 'tns-core-modules/platform'
 import * as types from 'tns-core-modules/utils/types'
+import { XmlParser } from 'tns-core-modules/xml'
 
 const XML_ATTRIBUTES = Object.freeze([
   'style',
@@ -108,6 +109,12 @@ export default class ViewNode {
           set(this.nativeView, key.substr(8), value)
         } else if (isIOS && key.startsWith('ios:')) {
           set(this.nativeView, key.substr(4), value)
+        } else if (key.endsWith('.decode')) {
+          set(
+            this.nativeView,
+            key.slice(0, -7),
+            XmlParser._dereferenceEntities(value)
+          )
         } else {
           set(this.nativeView, key, value)
         }

--- a/platform/nativescript/renderer/ViewNode.js
+++ b/platform/nativescript/renderer/ViewNode.js
@@ -96,7 +96,7 @@ export default class ViewNode {
   setAttribute(key, value) {
     try {
       if (XML_ATTRIBUTES.indexOf(key) !== -1) {
-        this.nativeView._applyXmlAttribute(key, value)
+        this.nativeView[key] = value
       } else {
         // detect expandable attrs for boolean values
         // See https://vuejs.org/v2/guide/components-props.html#Passing-a-Boolean
@@ -105,9 +105,9 @@ export default class ViewNode {
         }
 
         if (isAndroid && key.startsWith('android:')) {
-          set(this.nativeView, key.replace('android:', ''), value)
+          set(this.nativeView, key.substr(8), value)
         } else if (isIOS && key.startsWith('ios:')) {
-          set(this.nativeView, key.replace('ios:', ''), value)
+          set(this.nativeView, key.substr(4), value)
         } else {
           set(this.nativeView, key, value)
         }

--- a/platform/nativescript/runtime/components/frame.js
+++ b/platform/nativescript/runtime/components/frame.js
@@ -9,6 +9,20 @@ const propMap = {
   'transition-android': 'transitionAndroid'
 }
 
+const flipper = {
+  slide: "slideRight",
+  slideLeft: "slideRight",
+  slideRight: "slideLeft",
+  flip: "flipLeft",
+  flipRight: "flipLeft",
+  flipLeft: "flipRight",
+  fade: "fade",
+  explode: "explode",
+  curl: "curlDown",
+  curlUp: "curlDown",
+  curlDown: "curlUp"
+}
+
 export default {
   props: {
     id: {
@@ -25,6 +39,10 @@ export default {
     'transition-android': {
       type: [String, Object],
       default: ''
+    },
+    "back-transition": {
+      type: String,
+      default: "flip"
     },
     // injected by the template compiler
     hasRouterView: {
@@ -53,6 +71,7 @@ export default {
   },
   render(h) {
     let vnode = this.$slots.default
+
     if (this.hasRouterView && this.isBackNavigation) {
       this.isBackNavigation = false
       vnode = this.$el.nativeView.currentPage[PAGE_REF] || vnode
@@ -99,15 +118,27 @@ export default {
       })
     },
 
-    navigate(entry, back = false) {
+    notifyPageLeaving(isGoingBack) {
+      this.isGoingBack = isGoingBack;
+    },
+
+    navigate(entry, back = this.isGoingBack) {
       if (this.isBackNavigation) {
         console.log('skipping navigate()')
         return
       }
+
       const frame = this._getFrame()
+      const transition = this._composeTransition()
+
+      Object.assign(entry, transition, entry)
 
       if (back) {
-        return frame.goBack(entry)
+        if (this.backTransition === "flip") {
+          entry.transition.name = flipper[entry.transition.name]
+        }
+
+        return frame.navigate(entry)
       }
 
       entry.clearHistory && this.$emit('beforeReplace', entry)
@@ -139,8 +170,6 @@ export default {
         }
       })
       entry.create = () => page
-
-      Object.assign(entry, this._composeTransition(), entry)
 
       frame.navigate(entry)
     },

--- a/platform/nativescript/runtime/components/frame.js
+++ b/platform/nativescript/runtime/components/frame.js
@@ -34,8 +34,7 @@ export default {
   },
   data() {
     return {
-      properties: {},
-      pageRoutes: []
+      properties: {}
     }
   },
   created() {
@@ -100,8 +99,6 @@ export default {
           create: _ => pageVm.$el.nativeView
         })
       )
-
-      this.pageRoutes.push(pageVm.$route.fullPath)
     },
 
     notifyPageLeaving(history) {
@@ -135,18 +132,6 @@ export default {
         if (isBackNavigation) {
           page.off('navigatedFrom')
           this.$emit('back', entry)
-
-          if (!this.hasRouterView) return
-          this.isBackNavigation = true
-
-          // since this was a page navigation
-          // we need to find the previous page's path
-          // and navigate back to it
-          const lastPageRoute = this.pageRoutes.pop()
-          while (this.$router.currentRoute.fullPath !== lastPageRoute) {
-            this.$router.go(-1)
-          }
-          this.$router.go(-1)
         }
       })
       entry.create = () => page

--- a/platform/nativescript/runtime/components/frame.js
+++ b/platform/nativescript/runtime/components/frame.js
@@ -2,10 +2,10 @@ import { setFrame, getFrame, deleteFrame } from '../../util/frame'
 import { PAGE_REF } from './page'
 import { extend } from 'shared/util'
 
-let idCounter = 1;
+let idCounter = 1
 
 const propMap = {
-  'transition': 'transition',
+  transition: 'transition',
   'transition-ios': 'transitioniOS',
   'transition-android': 'transitionAndroid'
 }
@@ -17,7 +17,7 @@ export default {
     },
     transition: {
       type: [String, Object],
-      default: 'slide'
+      default: _ => ({ name: 'slide', duration: 200 })
     },
     'transition-ios': {
       type: [String, Object],
@@ -102,8 +102,8 @@ export default {
     },
 
     notifyPageLeaving(history) {
-      this.isGoingBack = history.isGoingBack;
-      this.currentEntry = history.currentEntry;
+      this.isGoingBack = history.isGoingBack
+      this.currentEntry = history.currentEntry
     },
 
     navigate(entry, back = this.isGoingBack) {

--- a/platform/nativescript/runtime/components/frame.js
+++ b/platform/nativescript/runtime/components/frame.js
@@ -6,9 +6,9 @@ import { ios } from 'tns-core-modules/application'
 let idCounter = 1
 
 const propMap = {
-  transition: 'transition',
-  'transition-ios': 'transitioniOS',
-  'transition-android': 'transitionAndroid'
+  'transition': 'transition',
+  'ios:transition': 'transitioniOS',
+  'android:transition': 'transitionAndroid'
 }
 
 export default {
@@ -20,11 +20,11 @@ export default {
       type: [String, Object],
       default: _ => ({ name: 'slide', duration: 200 })
     },
-    'transition-ios': {
+    'ios:transition': {
       type: [String, Object],
       default: ''
     },
-    'transition-android': {
+    'android:transition': {
       type: [String, Object],
       default: ''
     },

--- a/platform/nativescript/runtime/components/frame.js
+++ b/platform/nativescript/runtime/components/frame.js
@@ -1,4 +1,4 @@
-import { setFrame, deleteFrame } from '../../util/frame'
+import { setFrame, getFrame, deleteFrame } from '../../util/frame'
 import { PAGE_REF } from './page'
 
 let idCounter = 1;

--- a/platform/nativescript/runtime/components/frame.js
+++ b/platform/nativescript/runtime/components/frame.js
@@ -10,22 +10,6 @@ const propMap = {
   'transition-android': 'transitionAndroid'
 }
 
-const flipper = {
-  slide: "slideRight",
-  slideLeft: "slideRight",
-  slideRight: "slideLeft",
-  slideTop: "slideBottom",
-  slideBottom: "slideTop",
-  flip: "flipLeft",
-  flipRight: "flipLeft",
-  flipLeft: "flipRight",
-  fade: "fade",
-  explode: "explode",
-  curl: "curlDown",
-  curlUp: "curlDown",
-  curlDown: "curlUp"
-}
-
 export default {
   props: {
     id: {
@@ -43,10 +27,6 @@ export default {
       type: [String, Object],
       default: ''
     },
-    "back-transition": {
-      type: String,
-      default: "flip"
-    },
     // injected by the template compiler
     hasRouterView: {
       default: false
@@ -55,8 +35,7 @@ export default {
   data() {
     return {
       properties: {},
-      pageRoutes: [],
-      lastTransition: undefined
+      pageRoutes: []
     }
   },
   created() {
@@ -137,20 +116,9 @@ export default {
       }
 
       const frame = this._getFrame()
-      const transition = back && this.lastTransition
-                              ? this.lastTransition
-                              : this._composeTransition()
-
-      Object.assign(entry, transition, entry)
 
       if (back) {
-        if (this.backTransition === "flip") {
-          entry.transition.name = flipper[entry.transition.name]
-        }
-
-        this.lastTransition = undefined
-
-        return frame.navigate(entry)
+        return frame.goBack(this.isGoingBack ? undefined : entry)
       }
 
       entry.clearHistory && this.$emit('beforeReplace', entry)
@@ -183,7 +151,9 @@ export default {
       })
       entry.create = () => page
 
-      this.lastTransition = transition;
+      const transition = this._composeTransition()
+
+      Object.assign(entry, transition, entry)
 
       frame.navigate(entry)
     },

--- a/platform/nativescript/runtime/components/frame.js
+++ b/platform/nativescript/runtime/components/frame.js
@@ -1,6 +1,7 @@
 import { setFrame, getFrame, deleteFrame } from '../../util/frame'
 import { PAGE_REF } from './page'
 import { extend } from 'shared/util'
+import { ios } from 'tns-core-modules/application'
 
 let idCounter = 1
 
@@ -34,7 +35,8 @@ export default {
   },
   data() {
     return {
-      properties: {}
+      properties: {},
+      isGoingBack: false
     }
   },
   created() {
@@ -114,8 +116,11 @@ export default {
 
       const frame = this._getFrame()
 
-      if (back) {
-        return frame.goBack(this.isGoingBack ? undefined : entry)
+      if (back || (ios && this.isGoingBack === undefined)) {
+        frame.goBack(this.isGoingBack ? undefined : entry)
+
+        this.$router.history.isGoingBack = undefined
+        return
       }
 
       entry.clearHistory && this.$emit('beforeReplace', entry)

--- a/platform/nativescript/runtime/components/frame.js
+++ b/platform/nativescript/runtime/components/frame.js
@@ -3,10 +3,28 @@ import { PAGE_REF } from './page'
 
 let idCounter = 1;
 
+const propMap = {
+  'transition': 'transition',
+  'transition-ios': 'transitioniOS',
+  'transition-android': 'transitionAndroid'
+}
+
 export default {
   props: {
     id: {
       default: 'default'
+    },
+    transition: {
+      type: [String, Object],
+      default: 'slide'
+    },
+    'transition-ios': {
+      type: [String, Object],
+      default: ''
+    },
+    'transition-android': {
+      type: [String, Object],
+      default: ''
     },
     // injected by the template compiler
     hasRouterView: {
@@ -23,10 +41,10 @@ export default {
     let properties = {}
 
     if (getFrame(this.$props.id)) {
-      properties.id = this.$props.id + idCounter++;
+      properties.id = this.$props.id + idCounter++
     }
 
-    this.properties = Object.assign({}, this.$attrs, this.$props, properties);
+    this.properties = Object.assign({}, this.$attrs, this.$props, properties)
 
     setFrame(this.properties.id, this)
   },
@@ -52,6 +70,25 @@ export default {
   methods: {
     _getFrame() {
       return this.$el.nativeView
+    },
+
+    _composeTransition() {
+      const result = {}
+
+      for (const prop in propMap) {
+        if (this[prop]) {
+          const name = propMap[prop]
+          result[name] = {}
+
+          if (typeof this[prop] === 'string') {
+            result[name].name = this[prop]
+          } else {
+            Object.assign(result[name], this[prop])
+          }
+        }
+      }
+
+      return result
     },
 
     notifyPageMounted(pageVm) {
@@ -102,6 +139,9 @@ export default {
         }
       })
       entry.create = () => page
+
+      Object.assign(entry, this._composeTransition(), entry)
+
       frame.navigate(entry)
     },
 

--- a/platform/nativescript/runtime/components/frame.js
+++ b/platform/nativescript/runtime/components/frame.js
@@ -1,6 +1,8 @@
 import { setFrame, deleteFrame } from '../../util/frame'
 import { PAGE_REF } from './page'
 
+let idCounter = 1;
+
 export default {
   props: {
     id: {
@@ -13,14 +15,23 @@ export default {
   },
   data() {
     return {
+      properties: {},
       pageRoutes: []
     }
   },
   created() {
-    setFrame(this.$props.id, this)
+    let properties = {}
+
+    if (getFrame(this.$props.id)) {
+      properties.id = this.$props.id + idCounter++;
+    }
+
+    this.properties = Object.assign({}, this.$attrs, this.$props, properties);
+
+    setFrame(this.properties.id, this)
   },
   destroyed() {
-    deleteFrame(this.$props.id)
+    deleteFrame(this.properties.id)
   },
   render(h) {
     let vnode = this.$slots.default
@@ -32,7 +43,7 @@ export default {
     return h(
       'NativeFrame',
       {
-        attrs: Object.assign({}, this.$attrs, this.$props),
+        attrs: this.properties,
         on: this.$listeners
       },
       vnode

--- a/platform/nativescript/runtime/components/frame.js
+++ b/platform/nativescript/runtime/components/frame.js
@@ -111,10 +111,8 @@ export default {
     },
 
     notifyPageMounted(pageVm) {
-      this.$nextTick(() => {
-        this.navigate({
-          create: _ => pageVm.$el.nativeView
-        })
+      this.navigate({
+        create: _ => pageVm.$el.nativeView
       })
     },
 

--- a/platform/nativescript/runtime/components/frame.js
+++ b/platform/nativescript/runtime/components/frame.js
@@ -1,5 +1,6 @@
 import { setFrame, getFrame, deleteFrame } from '../../util/frame'
 import { PAGE_REF } from './page'
+import { extend } from 'shared/util'
 
 let idCounter = 1;
 
@@ -102,7 +103,7 @@ export default {
           if (typeof this[prop] === 'string') {
             result[name].name = this[prop]
           } else {
-            Object.assign(result[name], this[prop])
+            extend(result[name], this[prop])
           }
         }
       }
@@ -111,9 +112,13 @@ export default {
     },
 
     notifyPageMounted(pageVm) {
-      this.navigate({
-        create: _ => pageVm.$el.nativeView
-      })
+      this.$nextTick(_ =>
+        this.navigate({
+          create: _ => pageVm.$el.nativeView
+        })
+      )
+
+      this.pageRoutes.push(pageVm.$route.fullPath)
     },
 
     notifyPageLeaving(isGoingBack) {

--- a/platform/nativescript/runtime/components/list-view.js
+++ b/platform/nativescript/runtime/components/list-view.js
@@ -1,4 +1,5 @@
 import { VUE_VIEW } from './v-template'
+import { extend } from 'shared/util'
 
 export default {
   props: {
@@ -32,7 +33,7 @@ export default {
     items: {
       handler(newVal) {
         this.$refs.listView.setAttribute('items', newVal)
-        this.$refs.listView.nativeView.refresh()
+        this.refresh()
       },
       deep: true
     }
@@ -41,7 +42,7 @@ export default {
   created() {
     // we need to remove the itemTap handler from a clone of the $listeners
     // object because we are emitting the event ourselves with added data.
-    const listeners = Object.assign({}, this.$listeners)
+    const listeners = extend({}, this.$listeners)
     delete listeners.itemTap
     this.listeners = listeners
   },
@@ -50,7 +51,6 @@ export default {
     this.getItemContext = (item, index) =>
       getItemContext(item, index, this.$props['+alias'], this.$props['+index'])
 
-    this.$refs.listView.setAttribute('items', this.items)
     this.$refs.listView.setAttribute(
       '_itemTemplatesInternal',
       this.$templates.getKeyedTemplates()
@@ -64,7 +64,7 @@ export default {
     onItemTap(args) {
       this.$emit(
         'itemTap',
-        Object.assign({ item: this.items[args.index] }, args)
+        extend({ item: this.items[args.index] }, args)
       )
     },
     onItemLoading(args) {

--- a/platform/nativescript/runtime/components/list-view.js
+++ b/platform/nativescript/runtime/components/list-view.js
@@ -62,10 +62,7 @@ export default {
 
   methods: {
     onItemTap(args) {
-      this.$emit(
-        'itemTap',
-        extend({ item: this.items[args.index] }, args)
-      )
+      this.$emit('itemTap', extend({ item: this.items[args.index] }, args))
     },
     onItemLoading(args) {
       const index = args.index

--- a/platform/nativescript/runtime/components/page.js
+++ b/platform/nativescript/runtime/components/page.js
@@ -43,7 +43,7 @@ export default {
     const frame = this._findParentFrame()
 
     if (frame && this.$router) {
-      frame.notifyPageLeaving(this.$router.history.isGoingBack)
+      frame.notifyPageLeaving(this.$router.history)
     }
   }
 }

--- a/platform/nativescript/runtime/components/page.js
+++ b/platform/nativescript/runtime/components/page.js
@@ -18,7 +18,6 @@ export default {
 
     if (frame) {
       frame.notifyPageMounted(this)
-      frame.pageRoutes.push(this.$route.fullPath)
     }
 
     const handler = e => {

--- a/platform/nativescript/runtime/components/page.js
+++ b/platform/nativescript/runtime/components/page.js
@@ -15,6 +15,7 @@ export default {
     this.$el.nativeView[PAGE_REF] = this
 
     const frame = this._findParentFrame()
+
     if (frame) {
       frame.notifyPageMounted(this)
       frame.pageRoutes.push(this.$route.fullPath)
@@ -38,6 +39,14 @@ export default {
       }
 
       return parentFrame
+    }
+  },
+
+  beforeDestroy () {
+    const frame = this._findParentFrame()
+
+    if (frame && this.$router) {
+      frame.notifyPageLeaving(this.$router.history.isGoingBack)
     }
   }
 }

--- a/platform/nativescript/runtime/components/page.js
+++ b/platform/nativescript/runtime/components/page.js
@@ -11,6 +11,9 @@ export default {
       this.$slots.default
     )
   },
+  created() {
+    this.$vnode.parent.data.keepAlive = true
+  },
   mounted() {
     this.$el.nativeView[PAGE_REF] = this
 
@@ -38,12 +41,11 @@ export default {
       return parentFrame
     }
   },
-
-  beforeDestroy() {
+  deactivated() {
     const frame = this._findParentFrame()
 
     if (frame && this.$router) {
-      frame.notifyPageLeaving(this.$router.history)
+      return frame.notifyPageLeaving(this.$router.history)
     }
   }
 }

--- a/platform/nativescript/runtime/components/page.js
+++ b/platform/nativescript/runtime/components/page.js
@@ -21,15 +21,13 @@ export default {
       frame.pageRoutes.push(this.$route.fullPath)
     }
 
-    this.$nextTick(() => {
-      const handler = e => {
-        if (e.isBackNavigation) {
-          this.$el.nativeView.off('navigatedFrom', handler)
-          this.$destroy()
-        }
+    const handler = e => {
+      if (e.isBackNavigation) {
+        this.$el.nativeView.off('navigatedFrom', handler)
+        this.$destroy()
       }
-      this.$el.nativeView.on('navigatedFrom', handler)
-    })
+    }
+    this.$el.nativeView.on('navigatedFrom', handler)
   },
   methods: {
     _findParentFrame() {
@@ -42,7 +40,7 @@ export default {
     }
   },
 
-  beforeDestroy () {
+  beforeDestroy() {
     const frame = this._findParentFrame()
 
     if (frame && this.$router) {

--- a/platform/nativescript/runtime/components/page.js
+++ b/platform/nativescript/runtime/components/page.js
@@ -1,4 +1,5 @@
 export const PAGE_REF = '__vuePageRef__'
+import { ios } from 'tns-core-modules/application'
 
 export default {
   render(h) {
@@ -27,6 +28,14 @@ export default {
       if (e.isBackNavigation) {
         this.$el.nativeView.off('navigatedFrom', handler)
 
+        if (ios) {
+          this._findParentFrame().isGoingBack = undefined
+          const history = this.$router.history.history
+
+          history.index -= 1
+          history.updateRoute(history.stack[history.index])
+        }
+
         this.$vnode.parent.data.keepAlive = false
         this.$parent.$destroy()
       }
@@ -50,13 +59,13 @@ export default {
       frame.notifyPageLeaving(this.$router.history)
 
       if (this._watcher) {
-        this._watcher.teardown();
+        this._watcher.teardown()
       }
 
-      let i = this._watchers.length;
+      let i = this._watchers.length
 
       while (i--) {
-        this._watchers[i].teardown();
+        this._watchers[i].teardown()
       }
     }
   }

--- a/platform/nativescript/runtime/components/page.js
+++ b/platform/nativescript/runtime/components/page.js
@@ -45,7 +45,9 @@ export default {
     const frame = this._findParentFrame()
 
     if (frame && this.$router) {
-      return frame.notifyPageLeaving(this.$router.history)
+      frame.notifyPageLeaving(this.$router.history)
+
+      this._watcher.teardown();
     }
   }
 }

--- a/platform/nativescript/runtime/components/page.js
+++ b/platform/nativescript/runtime/components/page.js
@@ -26,7 +26,9 @@ export default {
     const handler = e => {
       if (e.isBackNavigation) {
         this.$el.nativeView.off('navigatedFrom', handler)
-        this.$destroy()
+
+        this.$vnode.parent.data.keepAlive = false
+        this.$parent.$destroy()
       }
     }
     this.$el.nativeView.on('navigatedFrom', handler)
@@ -47,7 +49,15 @@ export default {
     if (frame && this.$router) {
       frame.notifyPageLeaving(this.$router.history)
 
-      this._watcher.teardown();
+      if (this._watcher) {
+        this._watcher.teardown();
+      }
+
+      let i = this._watchers.length;
+
+      while (i--) {
+        this._watchers[i].teardown();
+      }
     }
   }
 }

--- a/platform/nativescript/runtime/modules/events.js
+++ b/platform/nativescript/runtime/modules/events.js
@@ -9,19 +9,18 @@ function add(event, handler, once, capture) {
   }
   if (once) {
     const oldHandler = handler
-    const _target = target // save current target element in closure
-    handler = function(...args) {
+    handler = (...args) => {
       const res = oldHandler.call(null, ...args)
       if (res !== null) {
-        remove(event, null, null, _target)
+        remove(event, null, null, target)
       }
     }
   }
   target.addEventListener(event, handler)
 }
 
-function remove(event, handler, capture, _target) {
-  (_target || target).removeEventListener(event)
+function remove(event, handler, capture, _target = target) {
+  _target.removeEventListener(event)
 }
 
 function updateDOMListeners(oldVnode, vnode) {

--- a/platform/nativescript/runtime/modules/events.js
+++ b/platform/nativescript/runtime/modules/events.js
@@ -10,11 +10,8 @@ function add(event, handler, once, capture) {
   if (once) {
     const oldHandler = handler
     const _target = target // save current target element in closure
-    handler = function(ev) {
-      const res =
-        arguments.length === 1
-          ? oldHandler(ev)
-          : oldHandler.apply(null, arguments)
+    handler = function(...args) {
+      const res = oldHandler.call(null, ...args)
       if (res !== null) {
         remove(event, null, null, _target)
       }
@@ -24,7 +21,7 @@ function add(event, handler, once, capture) {
 }
 
 function remove(event, handler, capture, _target) {
-  ;(_target || target).removeEventListener(event)
+  (_target || target).removeEventListener(event)
 }
 
 function updateDOMListeners(oldVnode, vnode) {

--- a/platform/nativescript/runtime/modules/transition.js
+++ b/platform/nativescript/runtime/modules/transition.js
@@ -76,7 +76,9 @@ export function enter(vnode, toggleDisplay) {
 
   const beforeEnterHook = isAppear ? beforeAppear || beforeEnter : beforeEnter
   const enterHook = isAppear
-    ? typeof appear === 'function' ? appear : enter
+    ? typeof appear === 'function'
+      ? appear
+      : enter
     : enter
   const afterEnterHook = isAppear ? afterAppear || afterEnter : afterEnter
   const enterCancelledHook = isAppear

--- a/platform/nativescript/runtime/node-ops.js
+++ b/platform/nativescript/runtime/node-ops.js
@@ -1,17 +1,11 @@
 import { default as document } from '../renderer/DocumentNode'
 import { trace } from '../util'
-import * as profiler from 'tns-core-modules/profiling'
 
 export const namespaceMap = {}
 
 export function createElement(tagName, vnode) {
-  const start = profiler.time()
-
-  const element = document.createElement(tagName)
-
-  trace(`CreateElement(${tagName})`, profiler.time() - start)
-
-  return element
+  trace(`CreateElement(${tagName})`)
+  return document.createElement(tagName)
 }
 
 export function createElementNS(namespace, tagName) {
@@ -32,22 +26,18 @@ export function createComment(text) {
 
 export function insertBefore(parentNode, newNode, referenceNode) {
   trace(`InsertBefore(${parentNode}, ${newNode}, ${referenceNode})`)
-  parentNode.insertBefore(newNode, referenceNode)
+  return parentNode.insertBefore(newNode, referenceNode)
 }
 
 export function removeChild(node, child) {
   trace(`RemoveChild(${node}, ${child})`)
-  node.removeChild(child)
+  return node.removeChild(child)
 }
 
 export function appendChild(node, child) {
-  const start = profiler.time()
+  trace(`AppendChild(${node}, ${child})`)
 
-  const element = node.appendChild(child)
-
-  trace(`AppendChild(${node}, ${child})`, profiler.time() - start)
-
-  return element
+  return node.appendChild(child)
 }
 
 export function parentNode(node) {

--- a/platform/nativescript/runtime/node-ops.js
+++ b/platform/nativescript/runtime/node-ops.js
@@ -1,11 +1,17 @@
 import { default as document } from '../renderer/DocumentNode'
 import { trace } from '../util'
+import * as profiler from 'tns-core-modules/profiling'
 
 export const namespaceMap = {}
 
 export function createElement(tagName, vnode) {
-  trace(`CreateElement(${tagName})`)
-  return document.createElement(tagName)
+  const start = profiler.time()
+
+  const element = document.createElement(tagName)
+
+  trace(`CreateElement(${tagName})`, profiler.time() - start)
+
+  return element
 }
 
 export function createElementNS(namespace, tagName) {
@@ -35,9 +41,13 @@ export function removeChild(node, child) {
 }
 
 export function appendChild(node, child) {
-  trace(`AppendChild(${node}, ${child})`)
+  const start = profiler.time()
 
-  node.appendChild(child)
+  const element = node.appendChild(child)
+
+  trace(`AppendChild(${node}, ${child})`, profiler.time() - start)
+
+  return element
 }
 
 export function parentNode(node) {

--- a/platform/nativescript/util/index.js
+++ b/platform/nativescript/util/index.js
@@ -69,13 +69,13 @@ const infoTrace = once(() => {
   )
 })
 
-export function trace(message) {
+export function trace(message, time) {
   if (_Vue && _Vue.config.silent) {
     return infoTrace()
   }
 
   console.log(
-    `{NSVue (Vue: ${VUE_VERSION} | NSVue: ${NS_VUE_VERSION})} -> ${message}`
+    `{NSVue (Vue: ${VUE_VERSION} | NSVue: ${NS_VUE_VERSION})} -> ${message}${ time ? ` - ran ${time}ms` : '' }`
   )
 }
 

--- a/platform/nativescript/util/index.js
+++ b/platform/nativescript/util/index.js
@@ -69,31 +69,27 @@ const infoTrace = once(() => {
   )
 })
 
-export function trace(message, time) {
+export function trace(message) {
   if (_Vue && _Vue.config.silent) {
     return infoTrace()
   }
 
   console.log(
-    `{NSVue (Vue: ${VUE_VERSION} | NSVue: ${NS_VUE_VERSION})} -> ${message}${ time ? ` - ran ${time}ms` : '' }`
+    `{NSVue (Vue: ${VUE_VERSION} | NSVue: ${NS_VUE_VERSION})} -> ${message}`
   )
 }
 
 export function before(original, thisArg, wrap) {
-  const __slice = Array.prototype.slice
-  return function() {
-    const args = __slice.call(arguments)
-    wrap.apply(null, args)
-    original.apply(thisArg, args)
+  return function(...args) {
+    wrap.call(null, ...args)
+    original.call(thisArg, ...args)
   }
 }
 
 export function after(original, thisArg, wrap) {
-  const __slice = Array.prototype.slice
-  return function() {
-    const args = __slice.call(arguments)
-    wrap.apply(null, args)
-    original.apply(thisArg, args)
+  return function(...args) {
+    wrap.call(null, ...args)
+    original.call(thisArg, ...args)
   }
 }
 


### PR DESCRIPTION
This PR handles fixes and enhancements to the Vue Router when used in {N}-Vue:

* Introduce NativeScriptHistory in the router plugin (a proxy to the Router's default AbstractHistory).
* Correctly handle back button in Android and iOS without recreating the whole previous Page.
* Add transition prop to Frame component - can be transition name or {N} transition object with name, duration and curve - you can use ios: and android: prefixes to specify platform.
* Possibility to specify the page transition on router.push/replace/go - with an {N} transition object after location, like this:
```javascript
this.$router.push(`/car-details-edit/${this.car.name}`, {
    transition: "slideTop"
});
```
* Remove buble plugin as NativeScript uses quite new V8/JSC engines with good ES6+ support.