### PR TITLE
fix(typings): were not implemented correctly

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,23 +1,59 @@
-// Typings for NativeScript-Vue
-declare module 'nativescript-vue' {
-    // import vue.js typings
-    import Vue from 'vue';
+// import vue.js typings
+// import Vue from 'vue';
+import { Vue, VueConstructor } from 'vue/types/vue'
+import { Page, NavigationEntry, Size } from 'tns-core-modules/ui/frame/frame'
+import { View } from 'tns-core-modules/ui/core/view'
 
-    // creat a nativescript vue class that extends vue.js
-    class NativeScriptVue extends Vue {
-        /**
-         * Registers NativeScript Plugin.
-         * @param elementName Name of the element to use in your template
-         * @param resolver  function to register the element
-         * @param meta meta associated with the element
-         */
-        static registerElement(elementName: string, resolver: Function, meta?: any): void;
-        
-        /**
-         * starts the nativescript application
-         */
-        $run(): void
-    }
+export type navigateTo = (
+    component: VueConstructor,
+    options?: NavigationEntry,
+    cb?: () => Page,
+) => Promise<Page>;
 
-    export = NativeScriptVue;
+export interface ModalOptions {
+    context?: any;
+    fullscreen?: boolean;
 }
+
+// creat a nativescript vue class that extends vue.js
+export interface NativeScriptVue<V = View> extends Vue {
+    nativeView: V
+
+    $navigateTo: navigateTo
+    $navigateBack: () => void
+
+    $modal?: { close: (data?) => Promise<typeof data> };
+
+    /**
+     * Open a modal using a component
+     * @param {typeof Vue} component
+     * @param {ModalOptions} options
+     * @returns {any}
+     */
+    $showModal: (component: typeof Vue, options?: ModalOptions) => Promise<any>;
+
+    /**
+     * starts the nativescript application
+     */
+    $run(): void
+    $start: () => void
+}
+
+export interface NativeScriptVueConstructor extends VueConstructor<NativeScriptVue> {
+    navigateTo: navigateTo
+    navigateBack: () => void
+}
+
+export const NativeScriptVue: NativeScriptVueConstructor
+
+export default NativeScriptVue;
+
+// export as namespace NativeScriptVue;
+
+/**
+ * Registers NativeScript Plugin.
+ * @param elementName Name of the element to use in your template
+ * @param resolver  function to register the element
+ * @param meta meta associated with the element
+ */
+export function registerElement(elementName: string, resolver: Function, meta?: any): void;

--- a/index.d.ts
+++ b/index.d.ts
@@ -15,7 +15,7 @@ export interface ModalOptions {
     fullscreen?: boolean;
 }
 
-// creat a nativescript vue class that extends vue.js
+// create a nativescript vue class that extends vue.js
 export interface NativeScriptVue<V = View> extends Vue {
     nativeView: V
 
@@ -35,7 +35,6 @@ export interface NativeScriptVue<V = View> extends Vue {
     /**
      * starts the nativescript application
      */
-    $run(): void
     $start: () => void
 }
 


### PR DESCRIPTION
Typings should not declare a module wereas they are already in the concerned module
Also, reusing Vue way of doing typings, and separating constructor from body to have better overriding capabilities

---
### `$refs` generic types

```typescript
import Vue from 'nativescript-vue'
import { RadSideDrawer } from 'nativescript-ui-sidedrawer'
import { Component } from 'components/decorator'

@Component({})
class TestComponent extends Vue {
    $refs: {
      drawer: Vue<RadSideDrawer>
      mainContent: Vue<StackLayout>
      drawerContent: Vue<StackLayout>,
    }

    mounted() {
        // `drawerView` will be of type RadSideDrawer
        const drawerView = this.$refs.drawer.nativeView
    }
}
```

### Vue augmentation

You can augment the same way you are augmenting with Vue:

```typescript
import Vue from 'vue'
import { Bus } from 'store/bus'
import * as moment from 'moment'
import { VueConstructor } from 'vue/types/vue'
import { Size } from 'tns-core-modules/ui/frame/frame'

import Components from 'components'
import * as http from 'http'

export interface VueDevice {
  screen: Size
  content: Size
  actionBar: Size
  navBar: Size
  statusBar: Size
  keyboard: Size
}

declare module 'vue/types/vue' {
  interface Vue {
    $http: typeof http,
    $bus: Bus
    $moment: typeof moment
    $device: VueDevice
  }

  interface VueConstructor {
    bus: Bus
    device: VueDevice
    moment: typeof moment
  }
}
```