### PR TITLE
Fix rollup problem not exporting Vue as the default element. So using NS-vue from TS is harder

### DIFF
--- a/platform/nativescript/framework.js
+++ b/platform/nativescript/framework.js
@@ -71,4 +71,10 @@ global.__onLiveSyncCore = () => {
   }
 }
 
+// Fix a rollup problem which does not define
+// module.export.default = Vue
+// so a `import Vue from 'nativescript-vue'` will
+// fail from a Typescript file
+Vue.default = Vue
+
 export default Vue


### PR DESCRIPTION
Probably there is a more elegant issue, but I'm not a roll-up expert.

See #300.