### PR TITLE
Fixed canBeLeftOpenTag typo mistake in defaultViewMeta.

### DIFF
--- a/platform/nativescript/element-registry.js
+++ b/platform/nativescript/element-registry.js
@@ -6,7 +6,7 @@ const defaultViewMeta = {
   skipAddToDom: false,
   isUnaryTag: false,
   tagNamespace: '',
-  canBeLeftOpen: false,
+  canBeLeftOpenTag: false,
   model: null,
   component: null
 }


### PR DESCRIPTION
It's obvious, function [canBeLeftOpenTag](https://github.com/nativescript-vue/nativescript-vue/blob/master/platform/nativescript/util/index.js#L13) is always returning undefined,
because canBeLeftOpen is a typo mistake, should be canBeLeftOpenTag.