### PR TITLE
feat: show error when --bundle option is not provided when executing some commands from {N} CLI

### DIFF
--- a/build/build.js
+++ b/build/build.js
@@ -17,6 +17,7 @@ if (process.argv[2]) {
 }
 
 build(builds)
+copyHooks()
 
 function build(builds) {
   let built = 0
@@ -60,4 +61,27 @@ function write(dest, code) {
 }
 function logError(e) {
   console.log(e)
+}
+
+function copyHooks() {
+  const sourceHooksDir = path.join(process.cwd(), "platform", "nativescript", "hooks");
+  if (!fs.existsSync(sourceHooksDir)) {
+    return;
+  }
+
+  const targetHooksDir = path.join(process.cwd(), "dist", "hooks");
+  if (!fs.existsSync(targetHooksDir)) {
+    fs.mkdirSync(targetHooksDir)
+  }
+
+  const sourceFiles = fs.readdirSync(sourceHooksDir);
+  sourceFiles.forEach(file => {
+    const sourcePath = path.join(sourceHooksDir, file);
+    const targetPath = path.join(targetHooksDir, file);
+    if (fs.existsSync(targetPath)) {
+      fs.unlinkSync(targetPath);
+    }
+
+    fs.copyFileSync(sourcePath, targetPath);
+  });
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,10 @@
   "main": "dist/index.js",
   "files": [
     "dist/index.js",
-    "index.d.ts"
+    "index.d.ts",
+    "dist/hooks/**",
+    "postinstall.js",
+    "preuninstall.js"
   ],
   "typings": "index.d.ts",
   "scripts": {
@@ -20,7 +23,9 @@
     "release": "node build/releaser.js",
     "release:notes": "node build/gen-release-notes.js",
     "changelog": "conventional-changelog --release-count 0 --outfile CHANGELOG.md --preset angular",
-    "commit": "git-cz"
+    "commit": "git-cz",
+    "postinstall": "node postinstall.js",
+    "preuninstall": "node preuninstall.js"
   },
   "repository": {
     "type": "git",
@@ -47,9 +52,23 @@
       "pan": "false",
       "core3": "true",
       "category": "Developer"
-    }
+    },
+    "hooks": [
+      {
+        "type": "before-checkForChanges",
+        "script": "dist/hooks/before-checkForChanges.js",
+        "inject": true
+      },
+      {
+        "type": "before-watch",
+        "script": "dist/hooks/before-watch.js",
+        "inject": true
+      }
+    ]
   },
-  "dependencies": {},
+  "dependencies": {
+    "nativescript-hook": "0.2.4"
+  },
   "devDependencies": {
     "@commitlint/cli": "^6.1.0",
     "@commitlint/config-conventional": "^6.1.0",

--- a/platform/nativescript/hooks/before-checkForChanges.js
+++ b/platform/nativescript/hooks/before-checkForChanges.js
@@ -1,0 +1,11 @@
+module.exports = function(hookArgs, $errors) {
+  const bundle =
+    hookArgs &&
+    hookArgs.projectChangesOptions &&
+    hookArgs.projectChangesOptions.bundle
+  if (!bundle) {
+    $errors.failWithoutHelp(
+      "Nativescript-vue doesn't work without --bundle option. Please specify --bundle option to the command and execute it again."
+    )
+  }
+}

--- a/platform/nativescript/hooks/before-watch.js
+++ b/platform/nativescript/hooks/before-watch.js
@@ -1,0 +1,12 @@
+module.exports = function(hookArgs, $errors) {
+  const bundle =
+    hookArgs &&
+    hookArgs.config &&
+    hookArgs.config.appFilesUpdaterOptions &&
+    hookArgs.config.appFilesUpdaterOptions.bundle
+  if (!bundle) {
+    $errors.failWithoutHelp(
+      "Nativescript-vue doesn't work without --bundle option. Please specify --bundle option to the command and execute it again."
+    )
+  }
+}

--- a/postinstall.js
+++ b/postinstall.js
@@ -1,0 +1,2 @@
+var hook = require("nativescript-hook")(__dirname);
+hook.postinstall();

--- a/preuninstall.js
+++ b/preuninstall.js
@@ -1,0 +1,2 @@
+var hook = require("nativescript-hook")(__dirname);
+hook.preuninstall();


### PR DESCRIPTION
Currently it is not possible to use vue template without bundle option. So we need to show an error in case when the user executes some command without bundle option.
This PR adds 2 hooks - before-checkForChanges and before-watch. Thеsе hooks will be triggered automatically by {N} CLI when the command is executed.