### PR TITLE
Fix/update type definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -4,9 +4,13 @@ import { Vue, VueConstructor } from 'vue/types/vue'
 import { Page, NavigationEntry, Size } from 'tns-core-modules/ui/frame/frame'
 import { View } from 'tns-core-modules/ui/core/view'
 
+export interface NavigationEntryVue extends NavigationEntry {
+    props?: Record<string, any>
+}
+
 export type navigateTo = (
     component: VueConstructor,
-    options?: NavigationEntry,
+    options?: NavigationEntryVue,
     cb?: () => Page,
 ) => Promise<Page>;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,7 @@
 // import vue.js typings
 // import Vue from 'vue';
 import { Vue, VueConstructor } from 'vue/types/vue'
-import { Page, NavigationEntry, Size } from 'tns-core-modules/ui/frame/frame'
+import { Page, NavigationEntry } from 'tns-core-modules/ui/frame/frame'
 import { View } from 'tns-core-modules/ui/core/view'
 
 export interface NavigationEntryVue extends NavigationEntry {


### PR DESCRIPTION
Currently, `navigateTo` accepts `props` property to pass props to navigated component, though type definitions of `NavigationEntry` do not describe such option. As instead, it suggests to pass properties via `context.propsData`, which is redundant.

In addition, usage of valid way to pass `props` will cause linting issues, due to mismatching type definition.

Fixed type for `NavigationEntry` by extending it with `props` field.

Also, removed unused type import `Size`.