### PR TITLE
Extend ModalOptions type definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -17,6 +17,7 @@ export type navigateTo = (
 export interface ModalOptions {
     context?: any;
     fullscreen?: boolean;
+    props?: Record<string, any>;
 }
 
 // create a nativescript vue class that extends vue.js


### PR DESCRIPTION
Updated type definitions for `ModalOptions` as `$showModal` can accept `props` same as `$navigateTo`.