### PR TITLE
feat(list-view): Add support for default ListView item template

### DIFF
--- a/platform/nativescript/runtime/components/list-view.js
+++ b/platform/nativescript/runtime/components/list-view.js
@@ -68,6 +68,10 @@ export default {
       this.$emit('itemTap', extend({ item: this.items[args.index] }, args))
     },
     onItemLoading(args) {
+      if (!this.$templates) {
+        return;
+      }
+ 
       const index = args.index
       const items = args.object.items
 

--- a/platform/nativescript/runtime/components/list-view.js
+++ b/platform/nativescript/runtime/components/list-view.js
@@ -50,6 +50,10 @@ export default {
   },
 
   mounted() {
+    if (!this.$templates) {
+        return;
+    }
+
     this.$refs.listView.setAttribute(
       '_itemTemplatesInternal',
       this.$templates.getKeyedTemplates()


### PR DESCRIPTION
By design the `ListView` from the `tns-core-modules` has a default `itemTemplate` (a basic Label that uses the toString() of the data item). In a NativeScript + Vue application if you do not declare an `<v-template`> you get an error.

This PR will allow you to declare a ListView without a declared `<v-template>`