### PR TITLE
fix: check correctly for passed `--bundle` option

### DIFF
--- a/platform/nativescript/hooks/before-checkForChanges.js
+++ b/platform/nativescript/hooks/before-checkForChanges.js
@@ -1,8 +1,9 @@
 module.exports = function(hookArgs, $errors) {
   const bundle =
     hookArgs &&
-    hookArgs.projectChangesOptions &&
-    hookArgs.projectChangesOptions.bundle
+    hookArgs.checkForChangesOpts &&
+    hookArgs.checkForChangesOpts.projectChangesOptions &&
+    hookArgs.checkForChangesOpts.projectChangesOptions.bundle
   if (!bundle) {
     $errors.failWithoutHelp(
       "Nativescript-vue doesn't work without --bundle option. Please specify --bundle option to the command and execute it again."


### PR DESCRIPTION
In case `--bundle` is not passed, the `before-checkForChanges` hook should stop the execution. However, in case `--bundle` is passed, it should allow the process to continue. Currently, even when `--bundle` is passed, the hook breaks the execution with error that you need to pass `--bundle`. The problem is that the hook checks the flag based on CLI's internal representation of the flag, but the internal structure has been changed since the PR that added this functionality has been added. Fix the hook to have correct check for bundle flag.