### PR TITLE
In-Component page events.

### DIFF
--- a/platform/nativescript/runtime/index.js
+++ b/platform/nativescript/runtime/index.js
@@ -12,6 +12,8 @@ import platformDirectives from './directives/index'
 
 import { mustUseProp, isReservedTag, isUnknownElement } from '../util/index'
 
+import pageEventsMixin from './mixins/pageEventsMixin'
+
 export const VUE_VM_REF = '__vue_vm_ref__'
 
 Vue.config.mustUseProp = mustUseProp
@@ -62,6 +64,9 @@ Vue.prototype.$start = function() {
   Object.values(getElementMap()).forEach(entry => {
     Vue.component(entry.meta.component.name, entry.meta.component)
   })
+
+  // register page events
+  Vue.mixin(pageEventsMixin)
 
   on(launchEvent, args => {
     if (self.$el) {

--- a/platform/nativescript/runtime/mixins/pageEventsMixin.js
+++ b/platform/nativescript/runtime/mixins/pageEventsMixin.js
@@ -1,0 +1,36 @@
+export default {
+  // page is loaded.
+  loaded(args) {},
+  // page is unloaded.
+  unloaded(args) {},
+  // when leaving a page (the navigation has ended).
+  navigatedFrom(args) {},
+  // when entering a page (the navigation has ended).
+  navigatedTo(args) {},
+  // when leaving a page (the navigation has started).
+  navigatingFrom(args) {},
+  // when entering a page (the navigation has started)
+  navigatingTo(args) {},
+
+  // look for page instance
+  mounted: function() {
+    if (this.$children == undefined || this.$children.length !== 1) return
+
+    if (this.$children[0].$el._tagName == 'nativepage') {
+      const nativePage = this.$children[0].$el._nativeView
+      if (nativePage != undefined) {
+        // fire page events
+        nativePage.on('loaded', args => this.$options.loaded(args))
+        nativePage.on('unloaded', args => this.$options.unloaded(args))
+        nativePage.on('navigatedFrom', args =>
+          this.$options.navigatedFrom(args)
+        )
+        nativePage.on('navigatedTo', args => this.$options.navigatedTo(args))
+        nativePage.on('navigatingFrom', args =>
+          this.$options.navigatingFrom(args)
+        )
+        nativePage.on('navigatingTo', args => this.$options.navigatingTo(args))
+      }
+    }
+  }
+}


### PR DESCRIPTION
Hello
I was thinking to simplify the use of Page events.

So instead of this:
``` html
<template>
    <Page @loaded="onLoaded" @navigatingTo="onNavigatingTo">

    </Page>
</template>

<script>
    export default {
        methods: {
            onLoaded(args){
                console.log('page is loaded.')
            },
            onNavigatingTo(args){
                console.log('page is navigating to.')
            }
        }
    }
</script>
```

Simply will be like this:
``` html
<template>
    <Page>

    </Page>
</template>

<script>
    export default {
        methods: {

        },
        loaded(args){
            console.log('page is loaded.')
        },
        navigatingTo(args){
            console.log('page is navigating to.')
        }
    }
</script>
```

What I did is a mixin that check if the page is the first and only child of the component, then create hooks that will be triggered by page events.
Available hooks:
``` js
        loaded(args) {
            console.log('loaded from page 2')
        },
        // page is unloaded.
        unloaded(args) {
            console.log('unloaded from page 2')
        },
        // when leaving a page (the navigation has ended).
        navigatedFrom(args) {
            console.log('navigatedFrom from page 2')
        },
        // when entering a page (the navigation has ended).
        navigatedTo(args) {
            console.log('navigatedTo from page 2')
        },
        // when leaving a page (the navigation has started).
        navigatingFrom(args) {
            console.log('navigatingFrom from page 2')
        },
        // when entering a page (the navigation has started)
        navigatingTo(args) {
            console.log('navigatingTo from page 2')
        }
```