### PR TITLE
Fix ObservableArray items in ListView (Fixes #464)

### DIFF
--- a/platform/nativescript/runtime/components/list-view.js
+++ b/platform/nativescript/runtime/components/list-view.js
@@ -1,10 +1,12 @@
 import { VUE_VIEW } from './v-template'
 import { extend } from 'shared/util'
+import { ObservableArray } from 'tns-core-modules/data/observable-array'
 
 export default {
   props: {
     items: {
-      type: Array,
+      type: Object,
+      validator: val => Array.isArray(val) || val instanceof ObservableArray,
       required: true
     },
     '+alias': {
@@ -65,7 +67,7 @@ export default {
 
   methods: {
     onItemTap(args) {
-      this.$emit('itemTap', extend({ item: this.items[args.index] }, args))
+      this.$emit('itemTap', extend({ item: this.getItem(args.index) }, args))
     },
     onItemLoading(args) {
       if (!this.$templates) {
@@ -75,10 +77,7 @@ export default {
       const index = args.index
       const items = args.object.items
 
-      const currentItem =
-        typeof items.getItem === 'function'
-          ? items.getItem(index)
-          : items[index]
+      const currentItem = this.getItem(index)
 
       const name = args.object._itemTemplateSelector(currentItem, index, items)
       const context = this.getItemContext(currentItem, index)
@@ -88,6 +87,11 @@ export default {
     },
     refresh() {
       this.$refs.listView.nativeView.refresh()
+    },
+    getItem(idx) {
+      return typeof this.items.getItem === 'function'
+        ? this.items.getItem(idx)
+        : this.items[idx]
     }
   }
 }

--- a/samples/app/464.js
+++ b/samples/app/464.js
@@ -1,0 +1,31 @@
+const Vue = require('./nativescript-vue')
+const {
+  ObservableArray
+} = require('tns-core-modules/data/observable-array/observable-array')
+
+Vue.config.debug = true
+Vue.config.silent = false
+
+new Vue({
+  data: {
+    items: new ObservableArray([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+  },
+  methods: {
+    onItemTap({ item }) {
+      this.items.push(`Item clicked: ${item} (shouldn't be \`undefined\`)`)
+    }
+  },
+  template: `
+    <Frame>
+      <Page class="page">
+        <ActionBar title="Home" class="action-bar" />
+        <ScrollView>
+          <ListView for="item in items" @itemTap="onItemTap">
+            <v-template>
+              <Label :text="item"/>
+            </v-template>
+          </ListView>
+        </ScrollView>
+      </Page>
+    </Frame>`
+}).$start()


### PR DESCRIPTION
Just a small patch to fix #464.

I changed the `items` prop's type to `Object` and instead added a validator function which ensures `items` is either an `Array` or an `ObservableArray`. I also adapted the `@itemTap` event emitter correspondingly.

**Edit:** I also added a sample for the issue