### PR TITLE
fix: make hooks compatible with CLI's 6.0.0 changes

### DIFF
--- a/platform/nativescript/hooks/before-checkForChanges.js
+++ b/platform/nativescript/hooks/before-checkForChanges.js
@@ -1,12 +1,19 @@
-module.exports = function(hookArgs, $errors) {
-  const bundle =
-    hookArgs &&
-    hookArgs.checkForChangesOpts &&
-    hookArgs.checkForChangesOpts.projectChangesOptions &&
-    hookArgs.checkForChangesOpts.projectChangesOptions.bundle
-  if (!bundle) {
-    $errors.failWithoutHelp(
-      "Nativescript-vue doesn't work without --bundle option. Please specify --bundle option to the command and execute it again."
-    )
+const { isBundleCheckRequired } = require('./helpers')
+
+module.exports = function(hookArgs, $errors, $injector) {
+  const shouldCheckBundleOption = isBundleCheckRequired($injector)
+
+  if (shouldCheckBundleOption) {
+    const bundle =
+      hookArgs &&
+      hookArgs.checkForChangesOpts &&
+      hookArgs.checkForChangesOpts.projectChangesOptions &&
+      hookArgs.checkForChangesOpts.projectChangesOptions.bundle
+
+    if (!bundle) {
+      $errors.failWithoutHelp(
+        "Nativescript-vue doesn't work without --bundle option. Please specify --bundle option to the command and execute it again."
+      )
+    }
   }
 }

--- a/platform/nativescript/hooks/before-watch.js
+++ b/platform/nativescript/hooks/before-watch.js
@@ -1,12 +1,18 @@
-module.exports = function(hookArgs, $errors) {
-  const bundle =
-    hookArgs &&
-    hookArgs.config &&
-    hookArgs.config.appFilesUpdaterOptions &&
-    hookArgs.config.appFilesUpdaterOptions.bundle
-  if (!bundle) {
-    $errors.failWithoutHelp(
-      "Nativescript-vue doesn't work without --bundle option. Please specify --bundle option to the command and execute it again."
-    )
+const { isBundleCheckRequired } = require('./helpers')
+
+module.exports = function(hookArgs, $errors, $injector) {
+  const shouldCheckBundleOption = isBundleCheckRequired($injector)
+
+  if (shouldCheckBundleOption) {
+    const bundle =
+      hookArgs &&
+      hookArgs.config &&
+      hookArgs.config.appFilesUpdaterOptions &&
+      hookArgs.config.appFilesUpdaterOptions.bundle
+    if (!bundle) {
+      $errors.failWithoutHelp(
+        "Nativescript-vue doesn't work without --bundle option. Please specify --bundle option to the command and execute it again."
+      )
+    }
   }
 }

--- a/platform/nativescript/hooks/helpers.js
+++ b/platform/nativescript/hooks/helpers.js
@@ -1,0 +1,14 @@
+function isBundleCheckRequired($injector) {
+  try {
+    const $staticConfig = $injector.resolve('$staticConfig')
+    const version = $staticConfig && $staticConfig.version
+    const majorVersion = (version || '').split('.')[0]
+    // If the major version is not available, probably we are in some new version of CLI, where the staticConfig is not available
+    // So it definitely should work with bundle;
+    return !majorVersion || +majorVersion < 6
+  } catch (err) {
+    return false
+  }
+}
+
+module.exports.isBundleCheckRequired = isBundleCheckRequired


### PR DESCRIPTION
In NativeScript CLI 6.0.0 release the bundle workflow will be the only one available. Currently, the nativescript-vue has some hooks that verify bundle is passed. There's no need of them for 6.0.0 release.
Implement a check based on the CLI's version and skip the validation in case CLI is 6.x.x or newer.