### PR TITLE
Allow developers set the default clearHistory and backstackVisible options when the page is mounted in a frame

### DIFF
--- a/platform/nativescript/runtime/components/frame.js
+++ b/platform/nativescript/runtime/components/frame.js
@@ -23,6 +23,16 @@ export default {
       required: false,
       default: null
     },
+    clearHistory: {
+      type: Boolean,
+      required: false,
+      default: false
+    },
+    backstackVisible: {
+      type: Boolean,
+      required: false,
+      default: true
+    },
     // injected by the template compiler
     hasRouterView: {
       default: false
@@ -89,6 +99,8 @@ export default {
 
     notifyPageMounted(pageVm) {
       let options = {
+        backstackVisible: this.backstackVisible,
+        clearHistory: this.clearHistory,
         create: () => pageVm.$el.nativeView
       }
 


### PR DESCRIPTION
See #513