### PR TITLE
Fix odd App crash while using v-if inside the RLV's template

### DIFF
--- a/platform/nativescript/renderer/ViewNode.js
+++ b/platform/nativescript/renderer/ViewNode.js
@@ -172,7 +172,7 @@ export default class ViewNode {
       return this.appendChild(childNode)
     }
 
-    if (referenceNode.parentNode !== this) {
+    if (referenceNode.parentNode && referenceNode.parentNode !== this) {
       throw new Error(
         `Can't insert child, because the reference node has a different parent.`
       )


### PR DESCRIPTION
Fixes https://github.com/NativeScript/nativescript-ui-feedback/issues/1182

I know this fix is kind of `code smells` as the real reason why the `referenceNode` has not any `parentNode` is the real cause of the issue. But I wanted @rigor789 to look at and point me in the right direction.