### PR TITLE
Fix listview cell recycling

### DIFF
--- a/platform/nativescript/runtime/components/list-view.js
+++ b/platform/nativescript/runtime/components/list-view.js
@@ -60,7 +60,7 @@ export default {
     }
 
     this.$refs.listView.setAttribute(
-      '_itemTemplatesInternal',
+      'itemTemplates',
       this.$templates.getKeyedTemplates()
     )
     this.$refs.listView.setAttribute('_itemTemplateSelector', (item, index) => {

--- a/platform/nativescript/runtime/components/list-view.js
+++ b/platform/nativescript/runtime/components/list-view.js
@@ -63,7 +63,7 @@ export default {
       'itemTemplates',
       this.$templates.getKeyedTemplates()
     )
-    this.$refs.listView.setAttribute('_itemTemplateSelector', (item, index) => {
+    this.$refs.listView.setAttribute('itemTemplateSelector', (item, index) => {
       return this.$templates.selectorFn(this.getItemContext(item, index))
     })
   },

--- a/platform/nativescript/util/index.js
+++ b/platform/nativescript/util/index.js
@@ -93,25 +93,6 @@ export function after(original, thisArg, wrap) {
   }
 }
 
-export function deepProxy(object, depth = 0) {
-  return new Proxy(object, {
-    get(target, key) {
-      if (key === 'toString' || key === 'valueOf') {
-        return () => ''
-      }
-
-      if (key === Symbol.toPrimitive) {
-        return hint => hint
-      }
-
-      if (depth > 10) {
-        throw new Error('deepProxy over 10 deep.')
-      }
-      return deepProxy({}, depth + 1)
-    }
-  })
-}
-
 export function updateDevtools() {
   if (global.__VUE_DEVTOOLS_GLOBAL_HOOK__) {
     try {


### PR DESCRIPTION
Fixes #565.

The `<NativeListView>` was not setting the `itemTemplates` property correctly.

I am not sure why it was setting `_itemTemplatesInternal` instead of `itemTemplates` before, but now it works. According to my tests, the cell recycling works properly with multi-templates and the scroll is visibly smoother.

For comparison of a before/after, see the [updated playground app](https://play.nativescript.org/?template=play-vue&id=KhyRrD&v=9). The list on the right is patched with this fix.