### PR TITLE
Suppress render logs

### DIFF
--- a/platform/nativescript/framework.js
+++ b/platform/nativescript/framework.js
@@ -6,7 +6,7 @@ import NavigatorPlugin from './plugins/navigator-plugin'
 import { setVue } from './util'
 
 Vue.config.silent = true
-Vue.config.supressRenderLogs = false
+Vue.config.suppressRenderLogs = false
 
 setVue(Vue)
 

--- a/platform/nativescript/framework.js
+++ b/platform/nativescript/framework.js
@@ -6,6 +6,7 @@ import NavigatorPlugin from './plugins/navigator-plugin'
 import { setVue } from './util'
 
 Vue.config.silent = true
+Vue.config.supressRenderLogs = false
 
 setVue(Vue)
 

--- a/platform/nativescript/util/index.js
+++ b/platform/nativescript/util/index.js
@@ -74,9 +74,11 @@ export function trace(message) {
     return infoTrace()
   }
 
-  console.log(
-    `{NSVue (Vue: ${VUE_VERSION} | NSVue: ${NS_VUE_VERSION})} -> ${message}`
-  )
+  if (!_Vue.config.supressRenderLogs) {
+    console.log(
+      `{NSVue (Vue: ${VUE_VERSION} | NSVue: ${NS_VUE_VERSION})} -> ${message}`
+    )
+  }
 }
 
 export function before(original, thisArg, wrap) {

--- a/platform/nativescript/util/index.js
+++ b/platform/nativescript/util/index.js
@@ -74,7 +74,7 @@ export function trace(message) {
     return infoTrace()
   }
 
-  if (!_Vue.config.supressRenderLogs) {
+  if (!_Vue.config.suppressRenderLogs) {
     console.log(
       `{NSVue (Vue: ${VUE_VERSION} | NSVue: ${NS_VUE_VERSION})} -> ${message}`
     )


### PR DESCRIPTION
Add option to suppress bunch of logs responsible for listing rendered elements. They are preventing developer to see actual Vue Warns in the templates.
This will tackle the problem mentioned in this issue https://github.com/nativescript-vue/nativescript-vue/issues/479