### PR TITLE
Use NS 6.2 scoped NPM packages

### DIFF
--- a/__tests__/renderer/ViewNode.test.js
+++ b/__tests__/renderer/ViewNode.test.js
@@ -8,7 +8,7 @@ jest.mock('renderer/utils', () => ({
   insertChild: jest.fn(),
   removeChild: jest.fn()
 }))
-jest.mock('tns-core-modules/platform', () => {
+jest.mock('@nativescript/core/platform', () => {
   return {
     isAndroid() {
     },

--- a/__tests__/renderer/utils.test.js
+++ b/__tests__/renderer/utils.test.js
@@ -1,18 +1,18 @@
 import * as utils from 'renderer/utils'
 
-jest.mock('tns-core-modules/ui/core/view', () => {
+jest.mock('@nativescript/core/ui/core/view', () => {
   return {
     View() {
     }
   }
 }, {virtual: true})
-jest.mock('tns-core-modules/ui/content-view', () => {
+jest.mock('@nativescript/core/ui/content-view', () => {
   return {
     ContentView() {
     }
   }
 }, {virtual: true})
-jest.mock('tns-core-modules/ui/layouts/layout-base', () => {
+jest.mock('@nativescript/core/ui/layouts/layout-base', () => {
   return {
     LayoutBase() {
     }
@@ -34,7 +34,7 @@ const getParentAndChild = (parentType) => {
 
 describe('utils', () => {
   test('isView', () => {
-    const View = require('tns-core-modules/ui/core/view').View;
+    const View = require('@nativescript/core/ui/core/view').View;
 
     expect(utils.isView()).toEqual(false)
     expect(utils.isView('a')).toEqual(false)
@@ -43,7 +43,7 @@ describe('utils', () => {
   })
 
   test('isLayout', () => {
-    const LayoutBase = require('tns-core-modules/ui/layouts/layout-base').LayoutBase;
+    const LayoutBase = require('@nativescript/core/ui/layouts/layout-base').LayoutBase;
 
     expect(utils.isLayout()).toEqual(false)
     expect(utils.isLayout('a')).toEqual(false)
@@ -52,7 +52,7 @@ describe('utils', () => {
   })
 
   test('isContentView', () => {
-    const ContentView = require('tns-core-modules/ui/content-view').ContentView;
+    const ContentView = require('@nativescript/core/ui/content-view').ContentView;
 
     expect(utils.isContentView()).toEqual(false)
     expect(utils.isContentView('a')).toEqual(false)
@@ -73,7 +73,7 @@ describe('utils', () => {
 
 
   test('insertChild adds childNode to Layout parent', () => {
-    const LayoutBase = require('tns-core-modules/ui/layouts/layout-base').LayoutBase;
+    const LayoutBase = require('@nativescript/core/ui/layouts/layout-base').LayoutBase;
     const {parentNode, childNode} = getParentAndChild(LayoutBase);
     parentNode.nativeView.addChild = jest.fn();
     childNode.nativeView.parent = null;
@@ -84,7 +84,7 @@ describe('utils', () => {
 
 
   test('insertChild adds childNode at index to Layout parent', () => {
-    const LayoutBase = require('tns-core-modules/ui/layouts/layout-base').LayoutBase;
+    const LayoutBase = require('@nativescript/core/ui/layouts/layout-base').LayoutBase;
     const {parentNode, childNode} = getParentAndChild(LayoutBase);
     parentNode.nativeView.insertChild = jest.fn();
     childNode.nativeView.parent = null;
@@ -94,7 +94,7 @@ describe('utils', () => {
   })
 
   test('insertChild removes childNode if the parent is the same Layout parent', () => {
-    const LayoutBase = require('tns-core-modules/ui/layouts/layout-base').LayoutBase;
+    const LayoutBase = require('@nativescript/core/ui/layouts/layout-base').LayoutBase;
     const {parentNode, childNode} = getParentAndChild(LayoutBase);
     parentNode.nativeView.getChildIndex = jest.fn().mockReturnValueOnce(1).mockReturnValueOnce(-1);
     parentNode.nativeView.removeChild = jest.fn();
@@ -112,7 +112,7 @@ describe('utils', () => {
   })
 
   test('insertChild adds comment node to ContentView parent', () => {
-    const ContentView = require('tns-core-modules/ui/content-view').ContentView;
+    const ContentView = require('@nativescript/core/ui/content-view').ContentView;
     const {parentNode, childNode} = getParentAndChild(ContentView);
     childNode.nodeType = 8;
     parentNode.nativeView._addView = jest.fn();
@@ -122,7 +122,7 @@ describe('utils', () => {
   })
 
   test('insertChild sets content of ContentView parent', () => {
-    const ContentView = require('tns-core-modules/ui/content-view').ContentView;
+    const ContentView = require('@nativescript/core/ui/content-view').ContentView;
     const {parentNode, childNode} = getParentAndChild(ContentView);
 
     utils.insertChild(parentNode, childNode);

--- a/build/config.js
+++ b/build/config.js
@@ -47,7 +47,7 @@ const builds = {
     banner: banner('NativeScript-Vue'),
     intro,
     external(id) {
-      return id.startsWith('tns-core-modules') || id.startsWith('weex')
+      return id.startsWith('@nativescript') || id.startsWith('tns-core-modules') || id.startsWith('weex')
     },
   },
   'nativescript-vue-template-compiler': {

--- a/platform/nativescript/element-registry.js
+++ b/platform/nativescript/element-registry.js
@@ -87,7 +87,7 @@ export function isKnownView(elementName) {
 
 registerElement(
   'ActionBar',
-  () => require('tns-core-modules/ui/action-bar').ActionBar,
+  () => require('@nativescript/core/ui/action-bar').ActionBar,
   {
     removeChild(parent, child) {
       try {
@@ -103,7 +103,7 @@ registerElement(
 
 registerElement(
   'ActionItem',
-  () => require('tns-core-modules/ui/action-bar').ActionItem
+  () => require('@nativescript/core/ui/action-bar').ActionItem
 )
 
 registerElement('android', null, {
@@ -116,7 +116,7 @@ registerElement('ios', null, {
 
 registerElement(
   'ListView',
-  () => require('tns-core-modules/ui/list-view').ListView,
+  () => require('@nativescript/core/ui/list-view').ListView,
   {
     component: builtInComponents.ListView
   }
@@ -124,12 +124,12 @@ registerElement(
 
 registerElement(
   'NavigationButton',
-  () => require('tns-core-modules/ui/action-bar').NavigationButton
+  () => require('@nativescript/core/ui/action-bar').NavigationButton
 )
 
 registerElement(
   'TabView',
-  () => require('tns-core-modules/ui/tab-view').TabView,
+  () => require('@nativescript/core/ui/tab-view').TabView,
   {
     model: {
       prop: 'selectedIndex',
@@ -141,7 +141,7 @@ registerElement(
 
 registerElement(
   'TabViewItem',
-  () => require('tns-core-modules/ui/tab-view').TabViewItem,
+  () => require('@nativescript/core/ui/tab-view').TabViewItem,
   {
     skipAddToDom: true,
     component: builtInComponents.TabViewItem
@@ -150,7 +150,7 @@ registerElement(
 
 registerElement(
   'BottomNavigation',
-  () => require('tns-core-modules/ui/bottom-navigation').BottomNavigation,
+  () => require('@nativescript/core/ui/bottom-navigation').BottomNavigation,
   {
     model: {
       prop: 'selectedIndex',
@@ -160,7 +160,7 @@ registerElement(
   }
 )
 
-registerElement('Tabs', () => require('tns-core-modules/ui/tabs').Tabs, {
+registerElement('Tabs', () => require('@nativescript/core/ui/tabs').Tabs, {
   model: {
     prop: 'selectedIndex',
     event: 'selectedIndexChange'
@@ -170,7 +170,7 @@ registerElement('Tabs', () => require('tns-core-modules/ui/tabs').Tabs, {
 
 registerElement(
   'TabStrip',
-  () => require('tns-core-modules/ui/tab-navigation-base/tab-strip').TabStrip,
+  () => require('@nativescript/core/ui/tab-navigation-base/tab-strip').TabStrip,
   {
     skipAddToDom: true,
     component: builtInComponents.TabStrip
@@ -180,7 +180,7 @@ registerElement(
 registerElement(
   'TabStripItem',
   () =>
-    require('tns-core-modules/ui/tab-navigation-base/tab-strip-item')
+    require('@nativescript/core/ui/tab-navigation-base/tab-strip-item')
       .TabStripItem,
   {
     skipAddToDom: true,
@@ -191,7 +191,7 @@ registerElement(
 registerElement(
   'TabContentItem',
   () =>
-    require('tns-core-modules/ui/tab-navigation-base/tab-content-item')
+    require('@nativescript/core/ui/tab-navigation-base/tab-content-item')
       .TabContentItem,
   {
     skipAddToDom: true,
@@ -210,7 +210,7 @@ registerElement('v-template', null, {
 // NS components which uses the automatic registerElement Vue wrapper
 // as they do not need any special logic
 
-registerElement('Label', () => require('tns-core-modules/ui/label').Label, {
+registerElement('Label', () => require('@nativescript/core/ui/label').Label, {
   model: {
     prop: 'text',
     event: 'textChange'
@@ -219,7 +219,7 @@ registerElement('Label', () => require('tns-core-modules/ui/label').Label, {
 
 registerElement(
   'DatePicker',
-  () => require('tns-core-modules/ui/date-picker').DatePicker,
+  () => require('@nativescript/core/ui/date-picker').DatePicker,
   {
     model: {
       prop: 'date',
@@ -230,35 +230,35 @@ registerElement(
 
 registerElement(
   'AbsoluteLayout',
-  () => require('tns-core-modules/ui/layouts/absolute-layout').AbsoluteLayout
+  () => require('@nativescript/core/ui/layouts/absolute-layout').AbsoluteLayout
 )
 registerElement(
   'ActivityIndicator',
-  () => require('tns-core-modules/ui/activity-indicator').ActivityIndicator
+  () => require('@nativescript/core/ui/activity-indicator').ActivityIndicator
 )
-registerElement('Border', () => require('tns-core-modules/ui/border').Border)
-registerElement('Button', () => require('tns-core-modules/ui/button').Button)
+registerElement('Border', () => require('@nativescript/core/ui/border').Border)
+registerElement('Button', () => require('@nativescript/core/ui/button').Button)
 registerElement(
   'ContentView',
-  () => require('tns-core-modules/ui/content-view').ContentView
+  () => require('@nativescript/core/ui/content-view').ContentView
 )
 registerElement(
   'DockLayout',
-  () => require('tns-core-modules/ui/layouts/dock-layout').DockLayout
+  () => require('@nativescript/core/ui/layouts/dock-layout').DockLayout
 )
 registerElement(
   'GridLayout',
-  () => require('tns-core-modules/ui/layouts/grid-layout').GridLayout
+  () => require('@nativescript/core/ui/layouts/grid-layout').GridLayout
 )
 registerElement(
   'HtmlView',
-  () => require('tns-core-modules/ui/html-view').HtmlView
+  () => require('@nativescript/core/ui/html-view').HtmlView
 )
-registerElement('Image', () => require('tns-core-modules/ui/image').Image)
-registerElement('img', () => require('tns-core-modules/ui/image').Image)
+registerElement('Image', () => require('@nativescript/core/ui/image').Image)
+registerElement('img', () => require('@nativescript/core/ui/image').Image)
 registerElement(
   'ListPicker',
-  () => require('tns-core-modules/ui/list-picker').ListPicker,
+  () => require('@nativescript/core/ui/list-picker').ListPicker,
   {
     model: {
       prop: 'selectedIndex',
@@ -266,18 +266,18 @@ registerElement(
     }
   }
 )
-registerElement('Page', () => require('tns-core-modules/ui/page').Page, {
+registerElement('Page', () => require('@nativescript/core/ui/page').Page, {
   skipAddToDom: true,
   component: builtInComponents.Page
 })
 
 registerElement(
   'Placeholder',
-  () => require('tns-core-modules/ui/placeholder').Placeholder
+  () => require('@nativescript/core/ui/placeholder').Placeholder
 )
 registerElement(
   'Progress',
-  () => require('tns-core-modules/ui/progress').Progress,
+  () => require('@nativescript/core/ui/progress').Progress,
   {
     model: {
       prop: 'value',
@@ -287,19 +287,19 @@ registerElement(
 )
 registerElement(
   'ProxyViewContainer',
-  () => require('tns-core-modules/ui/proxy-view-container').ProxyViewContainer
+  () => require('@nativescript/core/ui/proxy-view-container').ProxyViewContainer
 )
 // registerElement(
 //   'Repeater',
-//   () => require('tns-core-modules/ui/repeater').Repeater
+//   () => require('@nativescript/core/ui/repeater').Repeater
 // )
 registerElement(
   'ScrollView',
-  () => require('tns-core-modules/ui/scroll-view').ScrollView
+  () => require('@nativescript/core/ui/scroll-view').ScrollView
 )
 registerElement(
   'SearchBar',
-  () => require('tns-core-modules/ui/search-bar').SearchBar,
+  () => require('@nativescript/core/ui/search-bar').SearchBar,
   {
     model: {
       prop: 'text',
@@ -309,7 +309,7 @@ registerElement(
 )
 registerElement(
   'SegmentedBar',
-  () => require('tns-core-modules/ui/segmented-bar').SegmentedBar,
+  () => require('@nativescript/core/ui/segmented-bar').SegmentedBar,
   {
     model: {
       prop: 'selectedIndex',
@@ -319,32 +319,40 @@ registerElement(
 )
 registerElement(
   'SegmentedBarItem',
-  () => require('tns-core-modules/ui/segmented-bar').SegmentedBarItem
+  () => require('@nativescript/core/ui/segmented-bar').SegmentedBarItem
 )
-registerElement('Slider', () => require('tns-core-modules/ui/slider').Slider, {
-  model: {
-    prop: 'value',
-    event: 'valueChange'
+registerElement(
+  'Slider',
+  () => require('@nativescript/core/ui/slider').Slider,
+  {
+    model: {
+      prop: 'value',
+      event: 'valueChange'
+    }
   }
-})
+)
 registerElement(
   'StackLayout',
-  () => require('tns-core-modules/ui/layouts/stack-layout').StackLayout
+  () => require('@nativescript/core/ui/layouts/stack-layout').StackLayout
 )
 registerElement(
   'FlexboxLayout',
-  () => require('tns-core-modules/ui/layouts/flexbox-layout').FlexboxLayout
+  () => require('@nativescript/core/ui/layouts/flexbox-layout').FlexboxLayout
 )
-registerElement('Switch', () => require('tns-core-modules/ui/switch').Switch, {
-  model: {
-    prop: 'checked',
-    event: 'checkedChange'
+registerElement(
+  'Switch',
+  () => require('@nativescript/core/ui/switch').Switch,
+  {
+    model: {
+      prop: 'checked',
+      event: 'checkedChange'
+    }
   }
-})
+)
 
 registerElement(
   'TextField',
-  () => require('tns-core-modules/ui/text-field').TextField,
+  () => require('@nativescript/core/ui/text-field').TextField,
   {
     model: {
       prop: 'text',
@@ -354,7 +362,7 @@ registerElement(
 )
 registerElement(
   'TextView',
-  () => require('tns-core-modules/ui/text-view').TextView,
+  () => require('@nativescript/core/ui/text-view').TextView,
   {
     model: {
       prop: 'text',
@@ -364,7 +372,7 @@ registerElement(
 )
 registerElement(
   'TimePicker',
-  () => require('tns-core-modules/ui/time-picker').TimePicker,
+  () => require('@nativescript/core/ui/time-picker').TimePicker,
   {
     model: {
       prop: 'time',
@@ -374,11 +382,11 @@ registerElement(
 )
 registerElement(
   'WebView',
-  () => require('tns-core-modules/ui/web-view').WebView
+  () => require('@nativescript/core/ui/web-view').WebView
 )
 registerElement(
   'WrapLayout',
-  () => require('tns-core-modules/ui/layouts/wrap-layout').WrapLayout
+  () => require('@nativescript/core/ui/layouts/wrap-layout').WrapLayout
 )
 registerElement(
   'FormattedString',
@@ -388,32 +396,34 @@ registerElement('Span', () => require('tns-core-modules/text/span').Span)
 
 registerElement(
   'DetachedContainer',
-  () => require('tns-core-modules/ui/proxy-view-container').ProxyViewContainer,
+  () =>
+    require('@nativescript/core/ui/proxy-view-container').ProxyViewContainer,
   {
     skipAddToDom: true
   }
 )
 registerElement(
   'DetachedText',
-  () => require('tns-core-modules/ui/placeholder').Placeholder,
+  () => require('@nativescript/core/ui/placeholder').Placeholder,
   {
     skipAddToDom: true
   }
 )
 registerElement(
   'Comment',
-  () => require('tns-core-modules/ui/placeholder').Placeholder
+  () => require('@nativescript/core/ui/placeholder').Placeholder
 )
 
 registerElement(
   'Document',
-  () => require('tns-core-modules/ui/proxy-view-container').ProxyViewContainer,
+  () =>
+    require('@nativescript/core/ui/proxy-view-container').ProxyViewContainer,
   {
     skipAddToDom: true
   }
 )
 
-registerElement('Frame', () => require('tns-core-modules/ui/frame').Frame, {
+registerElement('Frame', () => require('@nativescript/core/ui/frame').Frame, {
   insertChild(parentNode, childNode, atIndex) {
     // if (normalizeElementName(childNode.tagName) === 'nativepage') {
     // parentNode.nativeView.navigate({ create: () => childNode.nativeView })

--- a/platform/nativescript/element-registry.js
+++ b/platform/nativescript/element-registry.js
@@ -390,9 +390,9 @@ registerElement(
 )
 registerElement(
   'FormattedString',
-  () => require('tns-core-modules/text/formatted-string').FormattedString
+  () => require('@nativescript/core/text/formatted-string').FormattedString
 )
-registerElement('Span', () => require('tns-core-modules/text/span').Span)
+registerElement('Span', () => require('@nativescript/core/text/span').Span)
 
 registerElement(
   'DetachedContainer',

--- a/platform/nativescript/framework.js
+++ b/platform/nativescript/framework.js
@@ -31,7 +31,7 @@ console.log = (function(log, inspect, Vue) {
 })(console.log, inspect, Vue)
 
 global.__onLiveSyncCore = () => {
-  const frame = require('tns-core-modules/ui/frame').topmost()
+  const frame = require('@nativescript/core/ui/frame').Frame.topmost()
   if (frame) {
     if (frame.currentPage && frame.currentPage.modal) {
       frame.currentPage.modal.closeModal()
@@ -39,7 +39,7 @@ global.__onLiveSyncCore = () => {
 
     if (frame.currentPage) {
       frame.currentPage.addCssFile(
-        require('tns-core-modules/application').getCssFileName()
+        require('@nativescript/core/application').getCssFileName()
       )
     }
   }

--- a/platform/nativescript/plugins/navigator-plugin.js
+++ b/platform/nativescript/plugins/navigator-plugin.js
@@ -29,7 +29,7 @@ export function getFrameInstance(frame) {
   if (isObject(frame) && isDef(frame.$el)) {
     frame = frame.$el.nativeView
   } else if (isPrimitive(frame)) {
-    frame = require('tns-core-modules/ui/frame').getFrameById(frame)
+    frame = require('@nativescript/core/ui/frame').Frame.getFrameById(frame)
   } else if (isDef(frame.nativeView)) {
     frame = frame.nativeView
   }

--- a/platform/nativescript/renderer/ViewNode.js
+++ b/platform/nativescript/renderer/ViewNode.js
@@ -92,7 +92,7 @@ export default class ViewNode {
 
   /* istanbul ignore next */
   setAttribute(key, value) {
-    const { isAndroid, isIOS } = require('tns-core-modules/platform')
+    const { isAndroid, isIOS } = require('@nativescript/core/platform')
     const nv = this.nativeView
 
     try {

--- a/platform/nativescript/renderer/ViewNode.js
+++ b/platform/nativescript/renderer/ViewNode.js
@@ -102,7 +102,7 @@ export default class ViewNode {
         // detect expandable attrs for boolean values
         // See https://vuejs.org/v2/guide/components-props.html#Passing-a-Boolean
         if (
-          require('tns-core-modules/utils/types').isBoolean(nv[key]) &&
+          require('@nativescript/core/utils/types').isBoolean(nv[key]) &&
           value === ''
         ) {
           value = true
@@ -116,7 +116,7 @@ export default class ViewNode {
           set(
             nv,
             key.slice(0, -7),
-            require('tns-core-modules/xml').XmlParser._dereferenceEntities(
+            require('@nativescript/core/xml').XmlParser._dereferenceEntities(
               value
             )
           )

--- a/platform/nativescript/renderer/utils.js
+++ b/platform/nativescript/renderer/utils.js
@@ -1,16 +1,18 @@
 export function isView(view) {
-  return view instanceof require('tns-core-modules/ui/core/view').View
+  return view instanceof require('@nativescript/core/ui/core/view').View
 }
 
 export function isLayout(view) {
   return (
     view instanceof
-    require('tns-core-modules/ui/layouts/layout-base').LayoutBase
+    require('@nativescript/core/ui/layouts/layout-base').LayoutBase
   )
 }
 
 export function isContentView(view) {
-  return view instanceof require('tns-core-modules/ui/content-view').ContentView
+  return (
+    view instanceof require('@nativescript/core/ui/content-view').ContentView
+  )
 }
 
 export function insertChild(parentNode, childNode, atIndex = -1) {

--- a/platform/nativescript/runtime/components/android.js
+++ b/platform/nativescript/runtime/components/android.js
@@ -1,7 +1,7 @@
 export default {
   functional: true,
   render(h, { children }) {
-    if (require('tns-core-modules/platform').isAndroid) {
+    if (require('@nativescript/core/platform').isAndroid) {
       return children
     }
   }

--- a/platform/nativescript/runtime/components/frame.js
+++ b/platform/nativescript/runtime/components/frame.js
@@ -88,7 +88,7 @@ export default {
     },
 
     _composeTransition(entry) {
-      const isAndroid = require('tns-core-modules/platform').isAndroid
+      const isAndroid = require('@nativescript/core/platform').isAndroid
       const platformEntryProp = `transition${isAndroid ? 'Android' : 'iOS'}`
       const entryProp = entry[platformEntryProp]
         ? platformEntryProp

--- a/platform/nativescript/runtime/components/ios.js
+++ b/platform/nativescript/runtime/components/ios.js
@@ -1,7 +1,7 @@
 export default {
   functional: true,
   render(h, { children }) {
-    if (require('tns-core-modules/platform').isIOS) {
+    if (require('@nativescript/core/platform').isIOS) {
       return children
     }
   }

--- a/platform/nativescript/runtime/components/list-view.js
+++ b/platform/nativescript/runtime/components/list-view.js
@@ -6,7 +6,7 @@ export default {
     items: {
       type: [Array, Object],
       validator: val => {
-        const ObservableArray = require('tns-core-modules/data/observable-array')
+        const ObservableArray = require('@nativescript/core/data/observable-array')
           .ObservableArray
         return Array.isArray(val) || val instanceof ObservableArray
       },

--- a/platform/nativescript/runtime/index.js
+++ b/platform/nativescript/runtime/index.js
@@ -1,7 +1,7 @@
 // Ensure `application` and `frame` modules are loaded
 // before overriding `global.__onLiveSyncCore`
-import { run, on, launchEvent } from 'tns-core-modules/application'
-import 'tns-core-modules/ui/frame'
+import { run, on, launchEvent } from '@nativescript/core/application'
+import '@nativescript/core/ui/frame'
 
 import { warn } from 'core/util/index'
 import { patch } from './patch'

--- a/samples/app/464.js
+++ b/samples/app/464.js
@@ -1,7 +1,7 @@
 const Vue = require('nativescript-vue')
 const {
   ObservableArray
-} = require('tns-core-modules/data/observable-array/observable-array')
+} = require('@nativescript/core/data/observable-array/observable-array')
 
 Vue.config.debug = true
 Vue.config.silent = false

--- a/samples/app/522.js
+++ b/samples/app/522.js
@@ -1,5 +1,5 @@
 import Vue from 'nativescript-vue'
-import { ObservableArray } from 'tns-core-modules/data/observable-array'
+import { ObservableArray } from '@nativescript/core/data/observable-array'
 
 Vue.config.debug = true
 Vue.config.silent = false
@@ -25,7 +25,7 @@ new Vue({
             </v-template>
           </ListView>
         </GridLayout>
-         
+
       </Page>
     </Frame>`
 }).$start()

--- a/samples/app/app-to-check-android-events.js
+++ b/samples/app/app-to-check-android-events.js
@@ -1,6 +1,6 @@
 const Vue = require('nativescript-vue')
 const application = require('tns-core-modules/application')
-const platform = require('tns-core-modules/platform')
+const platform = require('@nativescript/core/platform')
 
 Vue.config.silent = false
 Vue.config.debug = true

--- a/samples/app/app-to-check-android-events.js
+++ b/samples/app/app-to-check-android-events.js
@@ -1,5 +1,5 @@
 const Vue = require('nativescript-vue')
-const application = require('tns-core-modules/application')
+const application = require('@nativescript/core/application')
 const platform = require('@nativescript/core/platform')
 
 Vue.config.silent = false

--- a/samples/app/app-with-all-components.js
+++ b/samples/app/app-with-all-components.js
@@ -1,7 +1,7 @@
 const Vue = require('nativescript-vue')
-const frame = require('tns-core-modules/ui/frame')
+const frame = require('@nativescript/core/ui/frame')
 const platform = require('@nativescript/core/platform')
-const utils = require('tns-core-modules/utils/utils')
+const utils = require('@nativescript/core/utils/utils')
 
 Vue.config.debug = true
 Vue.config.silent = false

--- a/samples/app/app-with-all-components.js
+++ b/samples/app/app-with-all-components.js
@@ -1,6 +1,6 @@
 const Vue = require('nativescript-vue')
 const frame = require('tns-core-modules/ui/frame')
-const platform = require('tns-core-modules/platform')
+const platform = require('@nativescript/core/platform')
 const utils = require('tns-core-modules/utils/utils')
 
 Vue.config.debug = true

--- a/samples/app/package.json
+++ b/samples/app/package.json
@@ -1,5 +1,5 @@
 {
-  "main": "app-with-tabs.js",
+  "main": "app-with-all-components.js",
   "name": "nativescript-vue-tests",
   "version": "1.0.1"
 }

--- a/samples/package.json
+++ b/samples/package.json
@@ -5,10 +5,10 @@
   "nativescript": {
     "id": "org.nativescript.application",
     "tns-android": {
-      "version": "6.0.0"
+      "version": "6.2.0"
     },
     "tns-ios": {
-      "version": "6.0.1"
+      "version": "6.2.0"
     }
   },
   "scripts": {
@@ -23,7 +23,7 @@
     "nativescript-socketio": "^3.3.1",
     "nativescript-theme-core": "1.0.6",
     "nativescript-vue-devtools": "1.2.0",
-    "tns-core-modules": "6.0.1",
+    "tns-core-modules": "6.2.0",
     "vuex": "3.1.1"
   },
   "devDependencies": {

--- a/samples/webpack.config.js
+++ b/samples/webpack.config.js
@@ -15,8 +15,8 @@ const hashSalt = Date.now().toString();
 module.exports = env => {
   // Add your custom Activities, Services and other android app components here.
   const appComponents = [
-    "tns-core-modules/ui/frame",
-    "tns-core-modules/ui/frame/activity",
+    "@nativescript/core/ui/frame",
+    "@nativescript/core/ui/frame/activity",
   ];
 
   const platform = env && (env.android && "android" || env.ios && "ios");


### PR DESCRIPTION
Fixes #575 and #579

I really don't know if this is a worthy change as it would imply use NS >= 6.2 in our apps.

Maybe NS-vue 2.5.x is the version for looking ahead to the future or maybe the 3.x version is better for that.