### PR TITLE
fix(TabStripItem): bind attributes and listeners; support tap listener

### DIFF
--- a/platform/nativescript/runtime/components/tab-strip-item.js
+++ b/platform/nativescript/runtime/components/tab-strip-item.js
@@ -1,5 +1,14 @@
 export default {
-  template: `<NativeTabStripItem><slot /></NativeTabStripItem>`,
+  render(h) {
+    return h(
+      'NativeTabStripItem',
+      {
+        on: this.$listeners,
+        attrs: this.$attrs
+      },
+      this.$slots.default
+    )
+  },
 
   mounted() {
     let _nativeView = this.$el.nativeView


### PR DESCRIPTION
Updating to use the new Tabs and BottomNavigation components [recommended to use in place of TabView](https://www.nativescript.org/blog/tabs-and-bottomnavigation-nativescripts-two-new-components). However, I quickly noticed that the `@tap` binding isn't currently working on an individual `TabStripItem` while the `@tapItem` was working on the parent `TabStrip`.

I've changed the component to use a render function to bind both the event listeners and the attributes so that `@tap` now works on individual tab items.