### PR TITLE
fix: add minor fix to allow target being passed to

### DIFF
--- a/platform/nativescript/plugins/modal-plugin.js
+++ b/platform/nativescript/plugins/modal-plugin.js
@@ -1,4 +1,6 @@
+import { isObject, isDef, isPrimitive } from 'shared/util'
 import { updateDevtools } from '../util'
+import { VUE_ELEMENT_REF } from '../renderer/ElementNode'
 
 let sequentialCounter = 0
 
@@ -16,6 +18,16 @@ function serializeModalOptions(options) {
     })
     .concat(`uid: ${++sequentialCounter}`)
     .join(', ')
+}
+
+function getTargetView(target) {
+  if (isObject(target) && isDef(target.$el)) {
+    return target.$el.nativeView
+  } else if (isDef(target.nativeView)) {
+    return target.nativeView
+  } else if (target[VUE_ELEMENT_REF]) {
+    return target
+  }
 }
 
 function _findParentModalEntry(vm) {
@@ -91,7 +103,7 @@ export default {
         const modalPage = navEntryInstance.$mount().$el.nativeView
         updateDevtools()
 
-        options.target.nativeView.showModal(modalPage, options)
+        getTargetView(options.target).showModal(modalPage, options)
       })
     }
   }

--- a/platform/nativescript/plugins/modal-plugin.js
+++ b/platform/nativescript/plugins/modal-plugin.js
@@ -65,14 +65,20 @@ export default {
         }
 
         // build options object with defaults
-        options = Object.assign({}, options, {
-          context: null,
-          closeCallback: closeCb
-        })
+        options = Object.assign(
+          {
+            target: this.$root
+          },
+          options,
+          {
+            context: null,
+            closeCallback: closeCb
+          }
+        )
 
         const navEntryInstance = new Vue({
           name: 'ModalEntry',
-          parent: this.$root,
+          parent: options.target,
           methods: {
             closeCb
           },
@@ -85,7 +91,7 @@ export default {
         const modalPage = navEntryInstance.$mount().$el.nativeView
         updateDevtools()
 
-        this.$root.nativeView.showModal(modalPage, options)
+        options.target.nativeView.showModal(modalPage, options)
       })
     }
   }

--- a/samples/app/modals-on-top-of-modals.js
+++ b/samples/app/modals-on-top-of-modals.js
@@ -1,0 +1,86 @@
+const Vue = require('nativescript-vue')
+// const VueDevtools = require('nativescript-vue-devtools')
+
+// Vue.use(VueDevtools)
+
+Vue.config.debug = true
+Vue.config.silent = false
+
+const SecondaryModal = {
+  name: 'SecondaryModalComponent',
+  template: `
+   <Frame>
+    <Page>
+        <ActionBar title="Secondary Modal ActionBar"/>
+        <StackLayout>
+            <Label text="I'm a modal that should appear above the other."/>
+            <Button text="Close only this modal" @tap="$modal.close"/>
+        </StackLayout>
+    </Page>
+</Frame>
+  `
+}
+
+const ModalComponent = {
+  props: ['foo'],
+  name: 'ModalComponent',
+  template: `
+   <Frame>
+    <Page>
+        <ActionBar title="Modal ActionBar"/>
+        <StackLayout>
+            <Button text="Open another modal" @tap="openModal"/>
+        </StackLayout>
+    </Page>
+</Frame>
+  `,
+
+  methods: {
+    openModal() {
+      this.$showModal(SecondaryModal, { target: this })
+    }
+  }
+}
+new Vue({
+  data() {
+    return {
+      modalResult: 'No result yet.',
+      animated: true,
+      fullscreen: false,
+      stretched: false
+    }
+  },
+  template: `
+    <Frame>
+      <Page>
+        <ActionBar title="Modals" />
+
+        <StackLayout>
+          <FlexboxLayout justifyContent="center">
+            <Label text="Animated" />
+            <Switch v-model="animated" />
+          </FlexboxLayout>
+          <FlexboxLayout justifyContent="center">
+            <Label text="Stretched" />
+            <Switch v-model="stretched" />
+          </FlexboxLayout>
+          <FlexboxLayout justifyContent="center">
+            <Label text="Fullscreen" />
+            <Switch v-model="fullscreen" />
+          </FlexboxLayout>
+          <Button text="Open Modal" @tap="openModal"/>
+        </StackLayout>
+      </Page>
+    </Frame>
+  `,
+  methods: {
+    openModal() {
+      this.$showModal(ModalComponent, {
+        props: { foo: 'bar' },
+        animated: this.animated,
+        fullscreen: this.fullscreen,
+        stretched: this.stretched
+      })
+    }
+  }
+}).$start()

--- a/samples/app/modals-on-top-of-modals.js
+++ b/samples/app/modals-on-top-of-modals.js
@@ -30,6 +30,7 @@ const ModalComponent = {
         <ActionBar title="Modal ActionBar"/>
         <StackLayout>
             <Button text="Open another modal" @tap="openModal"/>
+            <Button text="Close this modal" @tap="$modal.close"/>
         </StackLayout>
     </Page>
 </Frame>


### PR DESCRIPTION
This is a minor fix, per @rigor789's suggestion on https://github.com/nativescript-vue/nativescript-vue/issues/612. This works, however, it is not tested since there were not very clear testing guidelines. Also, it's not a very elegant solution. There may be times where you're not aware that an other modal is open, etc. and may not know if you need to pass `target`. In that case, it's safer to just pass it. Anyway, I'm happy to discuss this further. Thanks!