### PR TITLE
fix(ios): fix white screen on start

### DIFF
--- a/platform/nativescript/plugins/navigator-plugin.js
+++ b/platform/nativescript/plugins/navigator-plugin.js
@@ -85,7 +85,6 @@ export default {
             })
         })
         const page = navEntryInstance.$mount().$el.nativeView
-        page.__isNavigatedTo = true
 
         updateDevtools()
 

--- a/platform/nativescript/runtime/components/frame.js
+++ b/platform/nativescript/runtime/components/frame.js
@@ -105,21 +105,13 @@ export default {
       return entry
     },
 
-    notifyPageMounted(pageVm) {
+    notifyFirstPageMounted(pageVm) {
       let options = {
         backstackVisible: this.backstackVisible,
         clearHistory: this.clearHistory,
         create: () => pageVm.$el.nativeView
       }
-
-      this.$nextTick(() => {
-        if (pageVm.$el.nativeView.__isNavigatedTo) {
-          // Ignore pages we've navigated to, since they are already on screen
-          return
-        }
-
-        this.navigate(options)
-      })
+      this.navigate(options)
     },
 
     navigate(entry, back = false) {

--- a/platform/nativescript/runtime/components/page.js
+++ b/platform/nativescript/runtime/components/page.js
@@ -18,8 +18,10 @@ export default {
 
     let frame = this._findParentFrame()
 
-    if (frame) {
-      frame.notifyPageMounted(this)
+    // we only need call this for the "defaultPage" of the frame
+    // which is equivalent to testing if any page is "current" in the frame
+    if (frame && (!frame.$el.nativeView.currentPage )) {
+      frame.notifyFirstPageMounted(this)
     }
 
     const handler = e => {


### PR DESCRIPTION
It comes from using nextTick.
nextTick was used to be able to read __isNavigatedTo from the mounted event.
I removed the need for __isNavigatedTo thus removing the need for the nextTick.