### PR TITLE
fix: fix navigateTo types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -11,9 +11,12 @@ import { Vue, VueConstructor } from 'vue/types/vue'
 // ListView ItemEventData with the addition of the item property
 export type NativeScriptVueItemEventData<T> = ItemEventData & { item: T }
 
+// TODO: define fully.
+type TargetFrame = any;
+
 export interface NavigationEntryVue extends NavigationEntry {
     props?: Record<string, any>,
-    frame?: any,
+    frame?: TargetFrame,
     resolveOnEvent?: Page.navigatingToEvent | Page.navigatedToEvent
 }
 
@@ -24,7 +27,9 @@ export type navigateTo = (
 ) => Promise<Page>
 
 export type navigateBack = (
-    options?: NavigationEntryVue,
+    options?: {
+        frame?: TargetFrame
+    },
     backstackEntry?: BackstackEntry,
 ) => void
 


### PR DESCRIPTION
The current navigateBack types are wrong; navigateBack is falsely advertised to accept a lot of options that only make sense for forward navigation.

___

On a related note, I see the linting setup in the project is outdated. In particular, `index.d.ts` which this PR goes against is not linted:

```
"prettier": "prettier --write \"{{platform,__test__}/**/*.js,samples/app/*.js}\""
```

I could come up with a PR that updates the linting setup to lint all source files.
I could also come up with a more powerful eslint + eslint-plugin-prettier setup.

Let me know if you have any interest in that.