### PR TITLE
NS7 live sync issue

### DIFF
--- a/platform/nativescript/framework.js
+++ b/platform/nativescript/framework.js
@@ -21,7 +21,7 @@ global.__onLiveSyncCore = () => {
 
     if (frame.currentPage) {
       frame.currentPage.addCssFile(
-        require('@nativescript/core').getCssFileName()
+        require('@nativescript/core/platform').getCssFileName()
       )
     }
   }


### PR DESCRIPTION
After the update to NS7 getCssFileName is no longer available in the core module you either have to call it from via import { Application } from '@nativescript/core'  then call Application.getCssFileName() or require('@nativescript/core/platform').getCssFileName() or require('@nativescript/core').Application.getCssFileName(); 

This is causing issues with live sync.