### PR TITLE
fix: wrong import for getCssFileName

### DIFF
--- a/platform/nativescript/framework.js
+++ b/platform/nativescript/framework.js
@@ -21,7 +21,7 @@ global.__onLiveSyncCore = () => {
 
     if (frame.currentPage) {
       frame.currentPage.addCssFile(
-        require('@nativescript/core').getCssFileName()
+        require('@nativescript/core/application').getCssFileName()
       )
     }
   }

--- a/platform/nativescript/framework.js
+++ b/platform/nativescript/framework.js
@@ -21,7 +21,7 @@ global.__onLiveSyncCore = () => {
 
     if (frame.currentPage) {
       frame.currentPage.addCssFile(
-        require('@nativescript/core/application').getCssFileName()
+        require('@nativescript/core').Application.getCssFileName()
       )
     }
   }


### PR DESCRIPTION
After the update to NS7 getCssFileName is no longer available in the core module you either have to call it from via import { Application } from '@nativescript/core' then call Application.getCssFileName() or require('@nativescript/core/application').getCssFileName() or require('@nativescript/core').Application.getCssFileName();

This is causing issues with live sync.