### PR TITLE
Fix once directive

### DIFF
--- a/platform/nativescript/runtime/modules/events.js
+++ b/platform/nativescript/runtime/modules/events.js
@@ -2,9 +2,19 @@ import { updateListeners } from 'core/vdom/helpers/update-listeners'
 
 let target
 
+function createOnceHandler(event, handler, capture) {
+  const _target = target // save current target element in closure
+  return function onceHandler() {
+    const res = handler.apply(null, arguments)
+    if (res !== null) {
+      remove(event, onceHandler, capture, _target)
+    }
+  }
+}
+
 function add(event, handler, once, capture) {
   if (capture) {
-    console.log('bubble phase not supported')
+    console.log('NativeScript-Vue do not support event in bubble phase.')
     return
   }
   if (once) {
@@ -30,7 +40,7 @@ function updateDOMListeners(oldVnode, vnode) {
   const on = vnode.data.on || {}
   const oldOn = oldVnode.data.on || {}
   target = vnode.elm
-  updateListeners(on, oldOn, add, remove, vnode.context)
+  updateListeners(on, oldOn, add, remove, createOnceHandler, vnode.context)
   target = undefined
 }
 

--- a/samples/app/748.js
+++ b/samples/app/748.js
@@ -1,0 +1,26 @@
+const Vue = require('nativescript-vue')
+
+Vue.config.debug = true
+Vue.config.silent = false
+
+new Vue({
+  data: {
+    foo: false
+  },
+  template: `
+    <Frame>
+      <Page>
+        <ActionBar title="Issue #748" />
+
+        <StackLayout>
+          <Button text="Only once" @tap.once="onlyOnce" />
+        </StackLayout>
+      </Page>
+    </Frame>
+  `,
+  methods: {
+    onlyOnce() {
+      console.log('this log should only appear once')
+    }
+  }
+}).$start()


### PR DESCRIPTION
- updateListener need a createOnceHandler in vue, add it
- update capture console.log for more clarity
- Add a reproduction sample
- Keep in line with [weex](https://github.com/vuejs/vue/blob/dev/src/platforms/weex/runtime/modules/events.js)

Initial error 
```
An uncaught Exception occurred on "main" thread.
Unable to start activity ComponentInfo{org.nativescript.application/com.tns.NativeScriptActivity}: com.tns.NativeScriptException: Calling js method onCreate failed
TypeError: createOnceHandler is not a function
```
