### PR TITLE
feat: add rootlayout to element-registry

### DIFF
--- a/platform/nativescript/element-registry.js
+++ b/platform/nativescript/element-registry.js
@@ -247,6 +247,7 @@ registerElement(
 //   'Repeater',
 //   () => require('@nativescript/core').Repeater
 // )
+registerElement('RootLayout', () => require('@nativescript/core').RootLayout)
 registerElement('ScrollView', () => require('@nativescript/core').ScrollView)
 registerElement('SearchBar', () => require('@nativescript/core').SearchBar, {
   model: {


### PR DESCRIPTION
This PR adds `RootLayout` to Vue's element-registry. This is the changes required for `RootLayout` to work with Vue (https://github.com/NativeScript/NativeScript/pull/8980). This is dependent on Nativescript's `release/8.0.0` branch.

cc @NathanWalker