### PR TITLE
Ensure that a unique, serialized key is only created once per navigateTo

### DIFF
--- a/platform/nativescript/plugins/navigator-plugin.js
+++ b/platform/nativescript/plugins/navigator-plugin.js
@@ -73,6 +73,9 @@ export default {
       // build options object with defaults
       options = Object.assign({}, defaultOptions, options)
 
+      // create a unique key to distinguish the pages
+      const serializedKey = serializeNavigationOptions(options)
+
       return new Promise(resolve => {
         const frame = getFrameInstance(options.frame)
         const navEntryInstance = new Vue({
@@ -84,7 +87,7 @@ export default {
           render: h =>
             h(component, {
               props: options.props,
-              key: serializeNavigationOptions(options)
+              key: serializedKey
             })
         })
         const page = navEntryInstance.$mount().$el.nativeView


### PR DESCRIPTION
When using `navigateTo`, there are certain conditions which can force the `render()` function of the `navEntryInstance` to be called multiple times. The problem is that a key is generated during the render function, and the key generation function has a global incrementing counter. When this occurs, a new navEntryItem is created, which the frame seems to dump promptly, or Vue ignores.

To be honest I haven't delved deeply into the inner working of the frame, or really understood how the render function gets called multiple times. Regardless, it does and ensuring that a unique key is only generated once will keep Vue happy.
