### PR TITLE
add alias nativescript-vue3 for plugins

### DIFF
--- a/nativescript.webpack.js
+++ b/nativescript.webpack.js
@@ -8,6 +8,7 @@ module.exports = (webpack) => {
 
   webpack.chainWebpack((config) => {
     config.resolve.alias.set('vue', 'nativescript-vue');
+    config.resolve.alias.set('nativescript-vue3', 'nativescript-vue');
     
     config.plugin("VueLoaderPlugin").use(VueLoaderPlugin);
 


### PR DESCRIPTION
We can include this alias in the core so that the plugins support vue2 and vue3. Here it is only one line of code but in the plugins we have to add it in all. I think it's better here and saves a lot of work. What do you think?