### PR TITLE
fix style undefined with hmr

### DIFF
--- a/src/renderer/modules/style.ts
+++ b/src/renderer/modules/style.ts
@@ -1,7 +1,7 @@
 import { NSVElement } from "../../dom";
 import { NormalizedStyle } from "@vue/shared";
 
-type Style = string | null;
+type Style = string | Record<string, string> | null;
 
 function normalizeStyle(style: NormalizedStyle | Style): NormalizedStyle {
   if (!style) {
@@ -32,7 +32,7 @@ function addStyleProperty(el: NSVElement, property: string, value: any) {
   property = normalizeProperty(property);
 
   if (!_sov.has(property)) {
-    _sov.set(property, el.style[property]);
+    _sov.set(property, value);
   }
 
   el.style[property] = value;
@@ -44,7 +44,7 @@ function removeStyleProperty(el: NSVElement, property: string) {
   property = normalizeProperty(property);
 
   // only delete styles we added
-  if (_sov.has(property) && _sov.get(property)) {
+  if (_sov.has(property)) {
     const originalValue = _sov.get(property);
     _sov.delete(property);
     // edge case: if a style property also exists as an attribute (ie backgroundColor)

--- a/src/renderer/modules/style.ts
+++ b/src/renderer/modules/style.ts
@@ -44,7 +44,7 @@ function removeStyleProperty(el: NSVElement, property: string) {
   property = normalizeProperty(property);
 
   // only delete styles we added
-  if (_sov.has(property)) {
+  if (_sov.has(property) && _sov.get(property)) {
     const originalValue = _sov.get(property);
     _sov.delete(property);
     // edge case: if a style property also exists as an attribute (ie backgroundColor)


### PR DESCRIPTION
I don't know why but this is breaking the hmr in my app, the `_sov.get(property)` returns `undefined` and when set to `el.style[property] = originalValue;` it breaks the app

Close: https://github.com/nativescript-vue/nativescript-vue/issues/1039