### PR TITLE
fix: handle views imported in script setup

### DIFF
--- a/demo/app/components/FragmentRootComponent.vue
+++ b/demo/app/components/FragmentRootComponent.vue
@@ -1,0 +1,5 @@
+<template>
+  <Label text="Hello Label!" />
+  <Button text="Hello Button!" />
+  <TextField text="Hello TextField!" />
+</template>

--- a/demo/app/components/GH1017.vue
+++ b/demo/app/components/GH1017.vue
@@ -1,0 +1,21 @@
+<!-- https://github.com/nativescript-vue/nativescript-vue/issues/1017 -->
+<script lang="ts" setup>
+import { Label, GridLayout, ContentView } from '@nativescript/core';
+
+import demo_ListView from './demo_ListView.vue';
+import FragmentRootComponent from './FragmentRootComponent.vue';
+</script>
+
+<template>
+  <GridLayout rows="auto, auto, *">
+    <Label text="Hello World" />
+
+    <StackLayout row="1">
+      <FragmentRootComponent />
+    </StackLayout>
+
+    <ContentView row="2">
+      <demo_ListView />
+    </ContentView>
+  </GridLayout>
+</template>

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,5 @@
 import type { CreateAppFunction } from '@vue/runtime-core';
 import {
-  createBaseVNode as createBaseVNodeCore,
   createBlock as createBlockCore,
   createElementBlock as createElementBlockCore,
   createElementVNode as createElementVNodeCore,
@@ -147,7 +146,6 @@ function wrapCreate<T>(originalFunction: T): T {
   }) as T;
 }
 
-export const createBaseVNode = wrapCreate(createBaseVNodeCore);
 export const createBlock = wrapCreate(createBlockCore);
 export const createElementBlock = wrapCreate(createElementBlockCore);
 export const createElementVNode = wrapCreate(createElementVNodeCore);


### PR DESCRIPTION
Fixes #1017

When importing a {N} view in `script setup` and using it with the same name in the template, Vue tries to resolve the {N} view as a component and it fails. With this change, we override the render helpers to hijack the first `type` argument, and detect when it's a `{N}` view (or a known component) and we return it's name instead, so the renderer can render it correctly.