### PR TITLE
Register ProxyViewContainer

### DIFF
--- a/src/nativescript/elements.ts
+++ b/src/nativescript/elements.ts
@@ -162,6 +162,7 @@ export function registerCoreElements() {
     () => require('@nativescript/core').Placeholder,
   );
   registerElement('Progress', () => require('@nativescript/core').Progress);
+  registerElement('ProxyViewContainer', () => require('@nativescript/core').ProxyViewContainer);
   registerElement('SearchBar', () => require('@nativescript/core').SearchBar, {
     model: {
       prop: 'text',


### PR DESCRIPTION
The `ProxyViewContainer` element was not registered which broke apps that were migrated from NSVue2.