### PR TITLE
feat: ability to emit and listen from modals and navigation to parent

### DIFF
--- a/src/plugins/modals.ts
+++ b/src/plugins/modals.ts
@@ -31,6 +31,7 @@ type ResolvableModalTarget = ComponentPublicInstance | NSVElement | View;
 
 export interface ModalOptions extends Partial<ShowModalOptions> {
   props?: Record<string, any>;
+  on?: Record<string, (...args: any[]) => any>;
   target?: ResolvableModalTarget;
 }
 
@@ -83,7 +84,7 @@ export async function $showModal<T = any>(
       // reopening is done in `closeCallback`
     };
 
-    let view = createNativeView(component, options.props, {
+    let view = createNativeView(component, options, {
       reload: reloadModal,
     });
 

--- a/src/plugins/navigation.ts
+++ b/src/plugins/navigation.ts
@@ -22,6 +22,7 @@ type ResolvableFrame = string | Ref | NSVElement | Frame | undefined;
 
 export interface NavigationOptions extends NavigationEntry {
   props?: Record<string, any>;
+  on?: Record<string, (...args: any[]) => any>;
   frame?: ResolvableFrame;
 }
 
@@ -122,7 +123,7 @@ export function $navigateTo(
       });
     };
 
-    let view = createNativeView<Page>(target, options?.props, {
+    let view = createNativeView<Page>(target, options, {
       /**
        * Called by @vue/runtime-core when the component is reloaded during HMR.
        */


### PR DESCRIPTION
Now we can do:

```ts
$navigateTo(ComponentNavigation, {
    on: {
      anyEmitChild(anyData) {
        console.log("on add items");
      },
    },
  });
```

And in `ComponentNavigation`
```ts
const emit = defineEmits(["anyEmitChild"]);

function onEmit(){
    emit("anyEmitChild", ""my data)
}
```

