### PR TITLE
More useful error logging

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -97,6 +97,14 @@ export const createApp = ((...args) => {
   app.use(modalsPlugin);
   app.use(navigationPlugin);
 
+  app.config.errorHandler =  (err, instance, info) => {
+    console.error((info ? `Error during execution of ${info}: ` : ``) + err);
+
+    if(__DEV__) {
+      throw err;
+    }
+  };
+
   return app;
 }) as CreateAppFunction<NSVElement>;
 


### PR DESCRIPTION
Log an error with the actual problem. Changes the console output when an error occurs from this:

![image](https://github.com/user-attachments/assets/677fd6b4-07e3-4151-b6f4-902905934189)
which doesn't give any information about what the error is


to this:
![image](https://github.com/user-attachments/assets/35423603-6931-41c9-b2ca-d2fa3c903189)
