### PR TITLE
remove multiple calls to useConfig vue and base

### DIFF
--- a/nativescript.webpack.js
+++ b/nativescript.webpack.js
@@ -61,8 +61,6 @@ function startVueDevtools(port, isAndroid = false) {
  * @param {typeof import("@nativescript/webpack")} webpack
  */
 module.exports = (webpack) => {
-  webpack.useConfig('vue');
-
   webpack.chainWebpack((config, env) => {
     const additionalDefines = {
       __VUE_PROD_DEVTOOLS__: false,


### PR DESCRIPTION
This line makes it go through the vue and base configuration twice in ns/webpack