### PR TITLE
chore: Fixed black background and white button text when preview 

### DIFF
--- a/packages/stackblitz-template/src/app.css
+++ b/packages/stackblitz-template/src/app.css
@@ -4,7 +4,8 @@ ActionBar {
   background-color: #65adf1;
   color: white;
 }
-page {
-  background: #fff;
-  color: #000
+
+Page {
+  background: white;
+  color: black;
 }

--- a/packages/template-blank/src/app.css
+++ b/packages/template-blank/src/app.css
@@ -4,7 +4,8 @@ ActionBar {
   background-color: #65adf1;
   color: white;
 }
-page {
-  background: #fff;
-  color: #000
+
+Page {
+  background: white;
+  color: black;
 }


### PR DESCRIPTION
Fixed black background and white button text when preview on iOS devices

![KakaoTalk_Photo_2025-06-13-10-48-51](https://github.com/user-attachments/assets/fbcdab5f-edba-44bc-93a4-42d79d186cdd)
