### PR TITLE
fix: webpack for stackblitz node 22

### DIFF
--- a/packages/stackblitz-template/package.json
+++ b/packages/stackblitz-template/package.json
@@ -14,7 +14,9 @@
     "@nativescript/webpack": "~5.0.24",
     "@types/node": "~22.14.0",
     "tailwindcss": "^4.1.3",
-    "typescript": "^5.8.3"
+    "typescript": "^5.8.3",
+    "webpack": "5.94.0",
+    "webpack-cli": "5.1.4"
   },
   "stackblitz": {
     "installDependencies": true,


### PR DESCRIPTION
- pins webpack and webpack-cli dependencies to prevent stackblitz error which prevents template from running:
```
Node.js v22.22.0 
[@nativescript/webpack] Error: Failed to patch VueLoader 
ValidationError: Invalid options object.
```

## Repro

https://nativescript.new/vue3
Scan with camera.

## Fix

See this example which pins the same from this PR: https://stackblitz.com/edit/nativescript-vue-nativescript-vue-2ua9pvbq?file=package.json&title=NativeScript%20Starter%20Vue3

cc/ @rigor789 