### PR TITLE
fix($showModal): re-present without the consumed transition on HMR reload

### DIFF
--- a/src/plugins/modals.ts
+++ b/src/plugins/modals.ts
@@ -98,10 +98,14 @@ export async function $showModal<T = any, P = any>(
         view.unmount();
         view.mount(root);
         openModal({
-          // todo: for this to work nicely, we'd need to add `animated: false` to `closeModal` as well
-          // but not currently possible without a core change.
-          // animated: false,
+          // A Transition/SharedTransition instance is single-use: its state
+          // was consumed by the presentation that just closed. Re-presenting
+          // with it leaves the new modal's dismissal completion permanently
+          // unfired, so no later close (HMR or user) ever calls back.
+          transition: undefined,
+          animated: false,
         });
+        modalStack.push(view);
         isReloading = false;
 
         return;
@@ -128,7 +132,10 @@ export async function $showModal<T = any, P = any>(
     };
     const closeModal = (...args: any[]) => {
       // remove view from modalStack
-      modalStack.splice(modalStack.indexOf(view), 1);
+      const stackIndex = modalStack.indexOf(view);
+      if (stackIndex > -1) {
+        modalStack.splice(stackIndex, 1);
+      }
 
       view.nativeView?.closeModal(...args);
     };


### PR DESCRIPTION
Fixes #1119

An HMR reload of a modal shown with a `SharedTransition` left the reopened modal permanently unclosable: the `isReloading` branch of `closeCallback` re-presented with the original `options` object, but a `Transition`/`SharedTransition` instance is single-use — its state (keyed by `options.transition.instance.id`) was consumed by the presentation that just closed. The re-presented controller kept a custom `transitioningDelegate` whose state no longer existed, so `dismissViewControllerAnimatedCompletion`'s completion never fired and no later close (HMR-driven or user-driven) ever reached `closeCallback`. Full trace in the issue.

Changes in `src/plugins/modals.ts`:

- The HMR re-present passes `transition: undefined` (and `animated: false`, which core supports here — the old TODO's concern was only about the close side) so the reopened modal presents plain and stays closable.
- The reopened `view` is pushed back onto `modalStack`, so the exported `$closeModal()` still targets it.
- `closeModal` guards `modalStack.indexOf(view)` returning `-1` before splicing — `splice(-1, 1)` was silently removing whichever modal was last in the stack.

Note: the issue diff also suggested `iosTransition: undefined` / `androidTransition: undefined`; those fields don't exist on core's `ShowModalOptions`, so they are omitted here (`transition` is the only modal transition field).

Verified on device against the repro in #1119: back-to-back HMR reload cycles on a `SharedTransition` modal close and reopen correctly, a user close of the reopened sheet resolves the `$showModal` promise, and a subsequent fresh `$showModal` with a new transition instance presents and drag-dismisses normally. `tsc --noEmit` and `prettier --check` pass.