### PR TITLE
ci: GitHub Actions, tests, and provenance publishing

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      actions:
+        patterns: ['*']
+
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      vue:
+        patterns: ['@vue/*', 'vue-loader']
+      nativescript:
+        patterns: ['@nativescript/*']
+      dev:
+        dependency-type: development

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,57 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  merge_group:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  SKIP_SIMPLE_GIT_HOOKS: 1
+
+jobs:
+  verify:
+    name: Verify (Node ${{ matrix.node }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node: [20, 24]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: ${{ matrix.node }}
+          cache: npm
+
+      - name: Install
+        run: npm ci
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Format
+        run: npm run format:check
+
+      - name: Test
+        run: npm test
+
+      - name: Build
+        run: npm run build
+
+      - name: Pack (dry run)
+        run: |
+          npm pack --dry-run
+          npm pack --dry-run ./packages/template-blank

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,115 @@
+name: Release
+
+# Publishes nativescript-vue and @nativescript-vue/template-blank to npm with
+# provenance when a v* tag is pushed. Create the tag with `npm run release`.
+#
+# Requires, once, outside this file:
+# - npm Trusted Publishing configured for both packages, pointing at this
+#   repository and this workflow file (npmjs.com → package → Settings →
+#   Trusted Publisher). No npm token is stored anywhere.
+# - A protected `npm` environment in the repository settings with required
+#   reviewers, so a tag push alone cannot publish.
+
+on:
+  push:
+    tags: ['v*']
+
+permissions: {}
+
+env:
+  SKIP_SIMPLE_GIT_HOOKS: 1
+
+jobs:
+  verify:
+    name: Verify
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install
+        run: npm ci
+
+      - name: Check tag matches package versions
+        run: node scripts/check-release-version.mjs "$GITHUB_REF_NAME"
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Format
+        run: npm run format:check
+
+      - name: Test
+        run: npm test
+
+      - name: Build
+        run: npm run build
+
+  publish:
+    name: Publish to npm
+    needs: verify
+    runs-on: ubuntu-latest
+    environment:
+      name: npm
+      url: https://www.npmjs.com/package/nativescript-vue
+    permissions:
+      contents: write # create the GitHub release
+      id-token: write # OIDC token for npm trusted publishing + provenance
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+          cache: npm
+          registry-url: https://registry.npmjs.org
+
+      # Trusted publishing needs npm >= 11.5.1.
+      - name: Update npm
+        run: npm install -g npm@latest
+
+      - name: Install
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Resolve dist-tag
+        id: tag
+        run: |
+          if [[ "$GITHUB_REF_NAME" == *-* ]]; then
+            echo "dist_tag=next" >> "$GITHUB_OUTPUT"
+          else
+            echo "dist_tag=latest" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Publish nativescript-vue
+        run: npm publish --provenance --access public --tag "${{ steps.tag.outputs.dist_tag }}"
+
+      - name: Publish @nativescript-vue/template-blank
+        run: npm publish --provenance --access public --tag "${{ steps.tag.outputs.dist_tag }}"
+        working-directory: packages/template-blank
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          args=(--generate-notes --verify-tag)
+          if [[ "$GITHUB_REF_NAME" == *-* ]]; then
+            args+=(--prerelease)
+          fi
+          gh release create "$GITHUB_REF_NAME" "${args[@]}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,14 +1,15 @@
 name: Release
 
-# Publishes nativescript-vue and @nativescript-vue/template-blank to npm with
+# Stages nativescript-vue and @nativescript-vue/template-blank on npm with
 # provenance when a v* tag is pushed. Create the tag with `npm run release`.
+# Nothing goes live from CI: a maintainer approves each staged version with
+# 2FA (`npm stage approve`), which is what publishes it.
 #
 # Requires, once, outside this file:
-# - npm Trusted Publishing configured for both packages, pointing at this
-#   repository and this workflow file (npmjs.com → package → Settings →
-#   Trusted Publisher). No npm token is stored anywhere.
-# - A protected `npm` environment in the repository settings with required
-#   reviewers, so a tag push alone cannot publish.
+# - npm Trusted Publishing for both packages, pointing at this repository,
+#   this workflow file and the `npm` environment, with only the
+#   "stage publish" permission. No npm token is stored anywhere.
+# - The `npm` environment in the repository settings.
 
 on:
   push:
@@ -55,13 +56,13 @@ jobs:
       - name: Build
         run: npm run build
 
-  publish:
-    name: Publish to npm
+  stage:
+    name: Stage on npm
     needs: verify
     runs-on: ubuntu-latest
     environment:
       name: npm
-      url: https://www.npmjs.com/package/nativescript-vue
+      url: https://www.npmjs.com/package/nativescript-vue?activeTab=versions
     permissions:
       contents: write # create the GitHub release
       id-token: write # OIDC token for npm trusted publishing + provenance
@@ -97,19 +98,40 @@ jobs:
             echo "dist_tag=latest" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Publish nativescript-vue
-        run: npm publish --provenance --access public --tag "${{ steps.tag.outputs.dist_tag }}"
+      - name: Stage nativescript-vue
+        run: npm stage publish --provenance --access public --tag "${{ steps.tag.outputs.dist_tag }}"
 
-      - name: Publish @nativescript-vue/template-blank
-        run: npm publish --provenance --access public --tag "${{ steps.tag.outputs.dist_tag }}"
+      - name: Stage @nativescript-vue/template-blank
+        run: npm stage publish --provenance --access public --tag "${{ steps.tag.outputs.dist_tag }}"
         working-directory: packages/template-blank
 
-      - name: Create GitHub release
+      # Draft until the staged versions are approved, so the GitHub release
+      # never points at a version that is not installable yet.
+      - name: Create draft GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          args=(--generate-notes --verify-tag)
+          args=(--draft --generate-notes --verify-tag)
           if [[ "$GITHUB_REF_NAME" == *-* ]]; then
             args+=(--prerelease)
           fi
           gh release create "$GITHUB_REF_NAME" "${args[@]}"
+
+      - name: Next steps
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          {
+            echo "## Staged, not published"
+            echo
+            echo "Both packages are staged on npm as \`$version\` with dist-tag \`${{ steps.tag.outputs.dist_tag }}\`."
+            echo "To publish, approve each with 2FA from a machine where you are logged in to npm:"
+            echo
+            echo '```sh'
+            echo "npm stage list nativescript-vue"
+            echo "npm stage approve <stage-id>"
+            echo "npm stage list @nativescript-vue/template-blank"
+            echo "npm stage approve <stage-id>"
+            echo '```'
+            echo
+            echo "Then publish the draft GitHub release for \`$GITHUB_REF_NAME\`."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,31 @@
+# Contributing
+
+## Development
+
+```sh
+npm install
+npm test            # vitest, runs the renderer against a stubbed @nativescript/core
+npm run typecheck
+npm run build
+```
+
+The `demo/` app resolves `nativescript-vue` straight from `src/`, so
+`cd demo && ns run ios|android` exercises uncommitted changes.
+
+Commits follow [Conventional Commits](https://www.conventionalcommits.org);
+a commit-msg hook enforces it.
+
+## Releasing
+
+Releases are published by GitHub Actions with npm provenance when a `v*` tag
+is pushed. Nothing publishes from a laptop.
+
+```sh
+npm run release -- 3.1.0        # or 3.1.0-beta.1 for a prerelease (npm tag: next)
+git push origin main v3.1.0
+```
+
+The script bumps `nativescript-vue` and `@nativescript-vue/template-blank`
+together, commits `release: 3.1.0` and creates the tag. The Release workflow
+verifies the tag matches the package versions, runs the checks, and then
+publishes from the protected `npm` environment.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,8 +17,9 @@ a commit-msg hook enforces it.
 
 ## Releasing
 
-Releases are published by GitHub Actions with npm provenance when a `v*` tag
-is pushed. Nothing publishes from a laptop.
+Releases are staged on npm by GitHub Actions with provenance when a `v*` tag
+is pushed, and go live only after a maintainer approves them with 2FA.
+No token can publish, from CI or from a laptop.
 
 ```sh
 npm run release -- 3.1.0        # or 3.1.0-beta.1 for a prerelease (npm tag: next)
@@ -27,5 +28,17 @@ git push origin main v3.1.0
 
 The script bumps `nativescript-vue` and `@nativescript-vue/template-blank`
 together, commits `release: 3.1.0` and creates the tag. The Release workflow
-verifies the tag matches the package versions, runs the checks, and then
-publishes from the protected `npm` environment.
+verifies the tag matches the package versions, runs the checks, stages both
+packages from the `npm` environment and creates a draft GitHub release.
+
+To publish what was staged:
+
+```sh
+npm stage list nativescript-vue
+npm stage approve <stage-id>                 # prompts for 2FA
+npm stage list @nativescript-vue/template-blank
+npm stage approve <stage-id>
+```
+
+Then publish the draft GitHub release. Approve the template after the
+runtime, since the template depends on the exact runtime version.

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,8 @@
         "lint-staged": "^17.5.0",
         "prettier": "^3.9.6",
         "simple-git-hooks": "^2.14.0",
-        "typescript": "^7.0.2"
+        "typescript": "^7.0.2",
+        "vitest": "^5.0.0"
       },
       "engines": {
         "node": ">=20"
@@ -990,6 +991,17 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@oxc-project/types": {
+      "version": "0.148.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.148.0.tgz",
+      "integrity": "sha512-Nm4s/jB+4FpFsPhWGEC4h7rzksesmtnMXomo6rCMcg/b8zLQuOziRgkCS1fxDCXOlJB/6Q8oABOZ/OP6RIPj9A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/oxc-project"
+      }
+    },
     "node_modules/@parcel/watcher": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.6.0.tgz",
@@ -1432,6 +1444,302 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@rolldown/binding-android-arm-eabi": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm-eabi/-/binding-android-arm-eabi-1.2.7.tgz",
+      "integrity": "sha512-EypzgnYCwyVY4NDHKzGmNJT5b+XaQEBniHxsMdeIQLB/tcCzZnhqrzHpZFbX9iaxx+5RiB8caATBtfvZP7zVxQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.7.tgz",
+      "integrity": "sha512-l17HE9EweWaqJZhuUuNBN/FzM62xw+DECVnJyvMsxn8vJFAGLy5QfLDoYAcronkAN8VxKZHezDpulHDPx95vFw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.7.tgz",
+      "integrity": "sha512-8ED8ELFvHXc6OCETIn4gXObPiaR6bckM/ipXtbzlPVDRMBfEGjCKgO90F9YtfdpDatVx/ZQw7aZ1vUMf/+T3Mw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.7.tgz",
+      "integrity": "sha512-/WPripjtiAIZ2tWY7ddijORT0Ujg87wxWW/qcoFVCKAWVDPhtY0xr7Dj0M3GyNGz60jGwTElhro/mkF9dT7dDQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.7.tgz",
+      "integrity": "sha512-14DI4NcqpvbICxSnGLx3PmtDaWqRP/KGSGb6C+JLLVPeZRl6dKdHba3pGsqT3vpdTqhEYIPG0MMQ8c0xYqoJxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.7.tgz",
+      "integrity": "sha512-bxrWIRvHWQvbJwi+VIie/kDJmQxcNE6xxWwZdqF/ExVAigtHkv54WTLQPb+QsZdnFy18fg7JPfWGL0RH6vwIlQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.7.tgz",
+      "integrity": "sha512-toOY2BChBZyuxU7OYX6Tn389di4IzAqPTycVcci0O7FSfBqzRB3RZn+K5Is6ANf4tmgRd/K1yZTsNTXbkXsnLg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.7.tgz",
+      "integrity": "sha512-lAIXTH/aiLRLxsTgQvfhjo4K1ydWIp00+V0voOr9beb/9ZmkUFrSIb03dXNFRgMNvkE6oGsF10ioQ6UsI+vS5Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.7.tgz",
+      "integrity": "sha512-kdnwS28Pkenp/mZMRwjXXXwxQ7pIsm+bF919LUK93BOyhcLsrVKdP2p9fxpiPNPAbNuch8ypQt0pm2P2LYCAGg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.7.tgz",
+      "integrity": "sha512-516OdsyLdr5E65paF3yBF55t8mfm9+gmtCsK3xI7XKXIT7EfRlHhxL8K/NR6Hu8BWSgF5+1w74lTL0+nxcc8Qw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.7.tgz",
+      "integrity": "sha512-r8/z8n7GFaYRln3xmP1Cxy0HH/HLM0uBUPkEuSVEfKGDA89M0FsZRZJRSwe/tJjRx+fpH/gjorfhB8tmEbSFLA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.7.tgz",
+      "integrity": "sha512-pAsE8iiDxUg1xBqdhrTfg45AVDVpirjz00sblEYClGNNcMnDb+e8beQgqIAw6LvauX/APvgxUnwrgun/YYGBhw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.7.tgz",
+      "integrity": "sha512-lTcIYmmnQQA8Or/2DatS6oSqcdLHvendjS+zLu+FwgToynWMRSmQdpM65fTANJgIS4mjbMOo5KT2lnT9SAb96w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.7.tgz",
+      "integrity": "sha512-e3Gu3WxbNk/UqQhxqU7YIYO+9ZBvWNz3U+h/qRFosscMFzdRPbXYSaSWgSnklv2fz1TgzBTcti2z35c/7irsHw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.7.tgz",
+      "integrity": "sha512-W/jg5qoRSqjsEv0+dZi4e687mcHqmVuU0P4fK6qS/xjetW2Gmc1W8j//z5nAeNcC8Ttm0hV46IjcYeuVwYhuiw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@simple-libs/child-process-utils": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@simple-libs/child-process-utils/-/child-process-utils-2.0.0.tgz",
@@ -1488,6 +1796,17 @@
         "node": ">=6"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/cookie": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.1.tgz",
@@ -1502,6 +1821,13 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/eslint": {
       "version": "8.44.2",
@@ -1536,10 +1862,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.6.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.6.0.tgz",
-      "integrity": "sha512-najjVq5KN2vsH2U/xyh2opaSEz6cZMR2SetLIlxlj08nOcmPOemJmUK2o4kUzfLqfrWE0PIrNeE16XhYDd3nqg==",
-      "license": "MIT"
+      "version": "26.5.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.5.0.tgz",
+      "integrity": "sha512-dVSGpriSoCgz8WnDNTuSSuSv1PC/ALXihO4ulRZt7Md8k9mlbdin3lGOcDE8SnWOgf513ByWlXd7BK4azmyg/A==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.9.0"
+      }
     },
     "node_modules/@types/yauzl": {
       "version": "2.10.0",
@@ -1889,6 +2218,64 @@
       ],
       "engines": {
         "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-5.0.0.tgz",
+      "integrity": "sha512-66PGTMIiVJP3t4a5yxU9qPtf7MdTBs8jmToMvy+HVflB3Yy13WJZTtPePdvU+wjRV02SKK5doLbSA6o9pwOmiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.31",
+        "@vitest/spy": "5.0.0",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^1.2.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/magic-string": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-1.2.3.tgz",
+      "integrity": "sha512-Bpb0W2TbLKOZ7vJnOUnVRGq3WL2p+ISV29M6hYPL1AFCpyKZpdr5ytiXoTSSxRVhg8YW7f65+6gbG8WG6PCa/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-5.0.0.tgz",
+      "integrity": "sha512-uy+luWBAPw9XfthoHi5AkfHUnuPYEESjl0p/r+meoBnU8bxg5GDQ3Ey8MjcJ6sqahkL4PFyrvfMJJBw7LbU06g==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vue/compiler-core": {
@@ -2454,6 +2841,16 @@
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
       "license": "MIT"
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/atob": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
@@ -2727,6 +3124,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -3434,7 +3841,6 @@
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -3815,6 +4221,16 @@
         "node": ">=0.8.x"
       }
     },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/express": {
       "version": "4.18.2",
       "resolved": "https://registry.npmjs.org/express/-/express-4.18.2.tgz",
@@ -4117,6 +4533,22 @@
       "integrity": "sha512-QMUezzXWII9EV5aTFXW1UBVUO77wYPpjqIF8/AviUCThNeSYZykpoTixUeaNNBwmCev0AMDWMAni+f8Hxb1IFw==",
       "dev": true,
       "license": "Unlicense"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
@@ -4858,6 +5290,291 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/lightningcss": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "peer": true,
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
@@ -5306,6 +6023,20 @@
       "optional": true,
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/on-finished": {
@@ -6031,6 +6762,41 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/rolldown": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.7.tgz",
+      "integrity": "sha512-g0EtLvBjTUB7jhyV0S/TCup3v/XSVl45vUIGbOGU4QPiyjTenCe4mKuFvW9fEgYmS2Fo42AUssRmNuMziXdrig==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@oxc-project/types": "=0.148.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm-eabi": "1.2.7",
+        "@rolldown/binding-android-arm64": "1.2.7",
+        "@rolldown/binding-darwin-arm64": "1.2.7",
+        "@rolldown/binding-darwin-x64": "1.2.7",
+        "@rolldown/binding-freebsd-x64": "1.2.7",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.2.7",
+        "@rolldown/binding-linux-arm64-gnu": "1.2.7",
+        "@rolldown/binding-linux-arm64-musl": "1.2.7",
+        "@rolldown/binding-linux-ppc64-gnu": "1.2.7",
+        "@rolldown/binding-linux-s390x-gnu": "1.2.7",
+        "@rolldown/binding-linux-x64-gnu": "1.2.7",
+        "@rolldown/binding-linux-x64-musl": "1.2.7",
+        "@rolldown/binding-openharmony-arm64": "1.2.7",
+        "@rolldown/binding-win32-arm64-msvc": "1.2.7",
+        "@rolldown/binding-win32-x64-msvc": "1.2.7"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -6364,6 +7130,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/simple-git-hooks": {
       "version": "2.14.0",
       "resolved": "https://registry.npmjs.org/simple-git-hooks/-/simple-git-hooks-2.14.0.tgz",
@@ -6491,6 +7264,13 @@
       "license": "BSD-3-Clause",
       "optional": true
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/stackframe": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
@@ -6506,6 +7286,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string-argv": {
       "version": "0.3.2",
@@ -6677,6 +7464,16 @@
       },
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-6.1.4.tgz",
+      "integrity": "sha512-9APumHG7r4yOk4X4WlkmE71aZcv1gvin1czO3OQ1U9iJcFA5Ja/ygyb0vPOVHTthFozUYs8CLoLUlM8grb2lTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/tinyexec": {
@@ -6873,6 +7670,12 @@
         "@typescript/typescript-win32-x64": "7.0.2"
       }
     },
+    "node_modules/undici-types": {
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.9.0.tgz",
+      "integrity": "sha512-KTDyRTYX8sWmKXAikPHHSyc63CRPETMctyjKFupcC6OBLXT3xsN0e9aF7m+mIXutFWpUXuedtowG7iLOzp0kQg==",
+      "license": "MIT"
+    },
     "node_modules/universalify": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
@@ -6979,6 +7782,222 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/vite": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.2.tgz",
+      "integrity": "sha512-cFKLV/PRgAUlIRm5WjMjJ86jrftzpqcgH+Us+DS8mI3CDNiH30Whrz8uHL3+MOLPAgqbMBAqWdAHAphOAM+z/Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "lightningcss": "^1.33.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.26",
+        "rolldown": "~1.2.4",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.4.0 || ^0.5.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+      "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-5.0.0.tgz",
+      "integrity": "sha512-gpsMNoRhMjMktVxPtstOH4/PJuPyovVaMDr4oDilXaGH1EcqM2OE96SoHT2VIQ6fTGtTjqmHDrEu2X9RQiXf8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/mocker": "5.0.0",
+        "chai": "^6.2.2",
+        "es-module-lexer": "^2.3.2",
+        "expect-type": "^1.4.0",
+        "magic-string": "^1.2.3",
+        "obug": "^2.1.4",
+        "picomatch": "^4.0.7",
+        "std-env": "^4.2.0",
+        "tinybench": "6.1.4",
+        "tinyexec": "1.3.0",
+        "tinyglobby": "^0.2.17",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^22.12.0 || ^24.0.0 || >=26.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "5.0.0",
+        "@vitest/browser-preview": "5.0.0",
+        "@vitest/browser-webdriverio": "^5.0.0-beta.5 || >=5.0.0",
+        "@vitest/coverage-istanbul": "5.0.0",
+        "@vitest/coverage-v8": "5.0.0",
+        "@vitest/ui": "5.0.0",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.4.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/es-module-lexer": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.2.tgz",
+      "integrity": "sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vitest/node_modules/magic-string": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-1.2.3.tgz",
+      "integrity": "sha512-Bpb0W2TbLKOZ7vJnOUnVRGq3WL2p+ISV29M6hYPL1AFCpyKZpdr5ytiXoTSSxRVhg8YW7f65+6gbG8WG6PCa/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+      "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest/node_modules/tinyexec": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+      "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/vue-loader": {
@@ -7247,6 +8266,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/wildcard": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,10 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "prepare": "simple-git-hooks",
-    "prepack": "npm run build"
+    "prepack": "npm run build",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "release": "node scripts/release.mjs"
   },
   "dependencies": {
     "@vue/compiler-sfc": "^3.5.42",
@@ -56,7 +59,8 @@
     "lint-staged": "^17.5.0",
     "prettier": "^3.9.6",
     "simple-git-hooks": "^2.14.0",
-    "typescript": "^7.0.2"
+    "typescript": "^7.0.2",
+    "vitest": "^5.0.0"
   },
   "simple-git-hooks": {
     "pre-commit": "npx --no-install lint-staged --config=package.json",

--- a/scripts/check-release-version.mjs
+++ b/scripts/check-release-version.mjs
@@ -1,0 +1,33 @@
+// Fails unless the given tag (vX.Y.Z) matches the version of every package
+// published by the release workflow.
+import { readFileSync } from 'node:fs';
+
+const tag = process.argv[2];
+if (!tag?.startsWith('v')) {
+  console.error(`Expected a tag like v1.2.3, got "${tag}"`);
+  process.exit(1);
+}
+const version = tag.slice(1);
+
+const read = (path) => JSON.parse(readFileSync(path, 'utf8'));
+const root = read('package.json');
+const template = read('packages/template-blank/package.json');
+
+const problems = [];
+if (root.version !== version) {
+  problems.push(`package.json is ${root.version}`);
+}
+if (template.version !== version) {
+  problems.push(`packages/template-blank/package.json is ${template.version}`);
+}
+if (template.dependencies['nativescript-vue'] !== version) {
+  problems.push(
+    `template-blank depends on nativescript-vue@${template.dependencies['nativescript-vue']}`,
+  );
+}
+
+if (problems.length) {
+  console.error(`Tag ${tag} does not match:\n  ${problems.join('\n  ')}`);
+  process.exit(1);
+}
+console.log(`Tag ${tag} matches all package versions.`);

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -1,0 +1,60 @@
+// Bumps every published package to the given version, commits and tags.
+// Nothing is pushed; pushing the tag triggers the Release workflow.
+//
+//   npm run release -- 3.1.0
+//   npm run release -- 3.1.0-beta.1
+import { execFileSync } from 'node:child_process';
+import { readFileSync, writeFileSync } from 'node:fs';
+
+const version = process.argv[2];
+const semver = /^\d+\.\d+\.\d+(-[0-9A-Za-z.-]+)?$/;
+if (!semver.test(version ?? '')) {
+  console.error('Usage: npm run release -- <version>');
+  process.exit(1);
+}
+
+const git = (...args) => execFileSync('git', args, { encoding: 'utf8' }).trim();
+
+if (git('status', '--porcelain')) {
+  console.error('Working tree is not clean.');
+  process.exit(1);
+}
+if (git('rev-parse', '--abbrev-ref', 'HEAD') !== 'main') {
+  console.error('Releases are cut from main.');
+  process.exit(1);
+}
+if (git('tag', '--list', `v${version}`)) {
+  console.error(`Tag v${version} already exists.`);
+  process.exit(1);
+}
+
+function updateJson(path, update) {
+  const json = JSON.parse(readFileSync(path, 'utf8'));
+  update(json);
+  writeFileSync(path, JSON.stringify(json, null, 2) + '\n');
+}
+
+execFileSync('npm', ['version', version, '--no-git-tag-version'], {
+  stdio: 'inherit',
+});
+updateJson('packages/template-blank/package.json', (pkg) => {
+  pkg.version = version;
+  pkg.dependencies['nativescript-vue'] = version;
+});
+updateJson('packages/stackblitz-template/package.json', (pkg) => {
+  pkg.dependencies['nativescript-vue'] = version;
+});
+
+git(
+  'add',
+  'package.json',
+  'package-lock.json',
+  'packages/template-blank/package.json',
+  'packages/stackblitz-template/package.json',
+);
+git('commit', '-m', `release: ${version}`);
+git('tag', '-a', `v${version}`, '-m', `v${version}`);
+
+console.log(
+  `\nTagged v${version}. To publish:\n\n  git push origin main v${version}\n`,
+);

--- a/src/nativescript/elements.ts
+++ b/src/nativescript/elements.ts
@@ -1,3 +1,4 @@
+import * as NSCore from '@nativescript/core';
 import {
   Frame as NSCFrame,
   Page as NSCPage,
@@ -11,73 +12,42 @@ import { logger } from '../util/logger';
 
 export function registerCoreElements() {
   // layouts
-  registerElement(
-    'AbsoluteLayout',
-    () => require('@nativescript/core').AbsoluteLayout,
-    { viewFlags: NSVViewFlags.LAYOUT_VIEW },
-  );
-  registerElement(
-    'DockLayout',
-    () => require('@nativescript/core').DockLayout,
-    {
-      viewFlags: NSVViewFlags.LAYOUT_VIEW,
-    },
-  );
-  registerElement(
-    'FlexboxLayout',
-    () => require('@nativescript/core').FlexboxLayout,
-    { viewFlags: NSVViewFlags.LAYOUT_VIEW },
-  );
-  registerElement(
-    'GridLayout',
-    () => require('@nativescript/core').GridLayout,
-    {
-      viewFlags: NSVViewFlags.LAYOUT_VIEW,
-    },
-  );
-  registerElement(
-    'RootLayout',
-    () => require('@nativescript/core').RootLayout,
-    {
-      viewFlags: NSVViewFlags.LAYOUT_VIEW,
-    },
-  );
-  registerElement(
-    'StackLayout',
-    () => require('@nativescript/core').StackLayout,
-    { viewFlags: NSVViewFlags.LAYOUT_VIEW },
-  );
-  registerElement(
-    'WrapLayout',
-    () => require('@nativescript/core').WrapLayout,
-    {
-      viewFlags: NSVViewFlags.LAYOUT_VIEW,
-    },
-  );
+  registerElement('AbsoluteLayout', () => NSCore.AbsoluteLayout, {
+    viewFlags: NSVViewFlags.LAYOUT_VIEW,
+  });
+  registerElement('DockLayout', () => NSCore.DockLayout, {
+    viewFlags: NSVViewFlags.LAYOUT_VIEW,
+  });
+  registerElement('FlexboxLayout', () => NSCore.FlexboxLayout, {
+    viewFlags: NSVViewFlags.LAYOUT_VIEW,
+  });
+  registerElement('GridLayout', () => NSCore.GridLayout, {
+    viewFlags: NSVViewFlags.LAYOUT_VIEW,
+  });
+  registerElement('RootLayout', () => NSCore.RootLayout, {
+    viewFlags: NSVViewFlags.LAYOUT_VIEW,
+  });
+  registerElement('StackLayout', () => NSCore.StackLayout, {
+    viewFlags: NSVViewFlags.LAYOUT_VIEW,
+  });
+  registerElement('WrapLayout', () => NSCore.WrapLayout, {
+    viewFlags: NSVViewFlags.LAYOUT_VIEW,
+  });
 
   // ContentViews
-  registerElement(
-    'ContentView',
-    () => require('@nativescript/core').ContentView,
-    { viewFlags: NSVViewFlags.CONTENT_VIEW },
-  );
-  registerElement(
-    'ScrollView',
-    () => require('@nativescript/core').ScrollView,
-    {
-      viewFlags: NSVViewFlags.CONTENT_VIEW,
-    },
-  );
+  registerElement('ContentView', () => NSCore.ContentView, {
+    viewFlags: NSVViewFlags.CONTENT_VIEW,
+  });
+  registerElement('ScrollView', () => NSCore.ScrollView, {
+    viewFlags: NSVViewFlags.CONTENT_VIEW,
+  });
 
   // ActionBar
-  registerElement('ActionItem', () => require('@nativescript/core').ActionItem);
-  registerElement(
-    'NavigationButton',
-    () => require('@nativescript/core').NavigationButton,
-  );
+  registerElement('ActionItem', () => NSCore.ActionItem);
+  registerElement('NavigationButton', () => NSCore.NavigationButton);
 
   // navigation
-  registerElement('Frame', () => require('@nativescript/core').Frame, {
+  registerElement('Frame', () => NSCore.Frame, {
     // todo: move into Frame.ts when we end up creating a component for Frame
     nodeOps: {
       insert(child: NSVElement, parent: NSVElement, atIndex?: number): void {
@@ -103,135 +73,100 @@ export function registerCoreElements() {
       },
     },
   });
-  registerElement('Page', () => require('@nativescript/core').Page, {
+  registerElement('Page', () => NSCore.Page, {
     viewFlags: NSVViewFlags.CONTENT_VIEW,
   });
 
   // html
-  registerElement('HtmlView', () => require('@nativescript/core').HtmlView);
-  registerElement('WebView', () => require('@nativescript/core').WebView);
+  registerElement('HtmlView', () => NSCore.HtmlView);
+  registerElement('WebView', () => NSCore.WebView);
 
   // components
-  registerElement(
-    'ActivityIndicator',
-    () => require('@nativescript/core').ActivityIndicator,
-  );
-  registerElement('Button', () => require('@nativescript/core').Button);
-  registerElement(
-    'DatePicker',
-    () => require('@nativescript/core').DatePicker,
-    {
-      model: {
-        prop: 'date',
-        event: 'dateChange',
-      },
+  registerElement('ActivityIndicator', () => NSCore.ActivityIndicator);
+  registerElement('Button', () => NSCore.Button);
+  registerElement('DatePicker', () => NSCore.DatePicker, {
+    model: {
+      prop: 'date',
+      event: 'dateChange',
     },
-  );
-  registerElement(
-    'FormattedString',
-    () => require('@nativescript/core').FormattedString,
-    {
-      nodeOps: {
-        insert(child, parent, atIndex) {
-          if (atIndex) {
-            parent.nativeView.spans.splice(atIndex, 0, child.nativeView);
-            return;
-          }
-          parent.nativeView.spans.push(child.nativeView);
-        },
-        remove(child, parent) {
-          const index = parent.nativeView.spans.indexOf(child.nativeView);
+  });
+  registerElement('FormattedString', () => NSCore.FormattedString, {
+    nodeOps: {
+      insert(child, parent, atIndex) {
+        if (atIndex) {
+          parent.nativeView.spans.splice(atIndex, 0, child.nativeView);
+          return;
+        }
+        parent.nativeView.spans.push(child.nativeView);
+      },
+      remove(child, parent) {
+        const index = parent.nativeView.spans.indexOf(child.nativeView);
 
-          if (index > -1) {
-            parent.nativeView.spans.splice(index, 1);
-          }
-        },
+        if (index > -1) {
+          parent.nativeView.spans.splice(index, 1);
+        }
       },
     },
-  );
-  registerElement('Image', () => require('@nativescript/core').Image);
-  registerElement('Label', () => require('@nativescript/core').Label);
-  registerElement(
-    'ListPicker',
-    () => require('@nativescript/core').ListPicker,
-    {
-      model: {
-        prop: 'selectedIndex',
-        event: 'selectedIndexChange',
-      },
+  });
+  registerElement('Image', () => NSCore.Image);
+  registerElement('Label', () => NSCore.Label);
+  registerElement('ListPicker', () => NSCore.ListPicker, {
+    model: {
+      prop: 'selectedIndex',
+      event: 'selectedIndexChange',
     },
-  );
-  registerElement(
-    'Placeholder',
-    () => require('@nativescript/core').Placeholder,
-  );
-  registerElement('Progress', () => require('@nativescript/core').Progress);
-  registerElement(
-    'ProxyViewContainer',
-    () => require('@nativescript/core').ProxyViewContainer,
-  );
-  registerElement('SearchBar', () => require('@nativescript/core').SearchBar, {
+  });
+  registerElement('Placeholder', () => NSCore.Placeholder);
+  registerElement('Progress', () => NSCore.Progress);
+  registerElement('ProxyViewContainer', () => NSCore.ProxyViewContainer);
+  registerElement('SearchBar', () => NSCore.SearchBar, {
     model: {
       prop: 'text',
       event: 'textChange',
     },
   });
-  registerElement(
-    'SegmentedBar',
-    () => require('@nativescript/core').SegmentedBar,
-    {
-      model: {
-        prop: 'selectedIndex',
-        event: 'selectedIndexChange',
-      },
+  registerElement('SegmentedBar', () => NSCore.SegmentedBar, {
+    model: {
+      prop: 'selectedIndex',
+      event: 'selectedIndexChange',
     },
-  );
-  registerElement(
-    'SegmentedBarItem',
-    () => require('@nativescript/core').SegmentedBarItem,
-  );
-  registerElement('Slider', () => require('@nativescript/core').Slider, {
+  });
+  registerElement('SegmentedBarItem', () => NSCore.SegmentedBarItem);
+  registerElement('Slider', () => NSCore.Slider, {
     model: {
       prop: 'value',
       event: 'valueChange',
     },
   });
-  registerElement('Span', () => require('@nativescript/core').Span);
-  registerElement('Switch', () => require('@nativescript/core').Switch, {
+  registerElement('Span', () => NSCore.Span);
+  registerElement('Switch', () => NSCore.Switch, {
     model: {
       prop: 'checked',
       event: 'checkedChange',
     },
   });
-  registerElement('TextField', () => require('@nativescript/core').TextField, {
+  registerElement('TextField', () => NSCore.TextField, {
     model: {
       prop: 'text',
       event: 'textChange',
     },
   });
-  registerElement('TextView', () => require('@nativescript/core').TextView, {
+  registerElement('TextView', () => NSCore.TextView, {
     model: {
       prop: 'text',
       event: 'textChange',
     },
   });
-  registerElement(
-    'TimePicker',
-    () => require('@nativescript/core').TimePicker,
-    {
-      model: {
-        prop: 'time',
-        event: 'timeChange',
-      },
+  registerElement('TimePicker', () => NSCore.TimePicker, {
+    model: {
+      prop: 'time',
+      event: 'timeChange',
     },
-  );
+  });
 
-  registerElement(
-    'TabViewItem',
-    () => require('@nativescript/core').TabViewItem,
-  );
+  registerElement('TabViewItem', () => NSCore.TabViewItem);
 
-  registerElement('TabView', () => require('@nativescript/core').TabView, {
+  registerElement('TabView', () => NSCore.TabView, {
     model: {
       prop: 'selectedIndex',
       event: 'selectedIndexChange',

--- a/test/dom.test.ts
+++ b/test/dom.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+import { NSVElement, NSVText, NSVComment } from '../src';
+import { elementChildren, nativeChildren } from './helpers';
+
+function label(text: string) {
+  const el = new NSVElement('Label');
+  el.setAttribute('text', text);
+  return el;
+}
+
+describe('NSVElement tree operations', () => {
+  it('appends children to layout views in order', () => {
+    const layout = new NSVElement('StackLayout');
+    layout.appendChild(label('A'));
+    layout.appendChild(label('B'));
+
+    expect(elementChildren(layout)).toEqual(['A', 'B']);
+    expect(nativeChildren(layout)).toEqual(['A', 'B']);
+  });
+
+  it('inserts before an anchor, skipping non-visual nodes for the native index', () => {
+    const layout = new NSVElement('StackLayout');
+    const a = label('A');
+    const c = label('C');
+    layout.appendChild(a);
+    layout.appendChild(new NSVComment(''));
+    layout.appendChild(c);
+
+    layout.insertBefore(label('B'), c);
+
+    expect(elementChildren(layout)).toEqual(['A', 'B', 'C']);
+    expect(nativeChildren(layout)).toEqual(['A', 'B', 'C']);
+  });
+
+  it('removes children from both trees', () => {
+    const layout = new NSVElement('StackLayout');
+    const a = label('A');
+    const b = label('B');
+    layout.appendChild(a);
+    layout.appendChild(b);
+
+    layout.removeChild(a);
+
+    expect(elementChildren(layout)).toEqual(['B']);
+    expect(nativeChildren(layout)).toEqual(['B']);
+    expect(a.parentNode).toBeNull();
+    expect(a.nativeView.parent).toBeNull();
+  });
+
+  it('sets content on content views', () => {
+    const page = new NSVElement('Page');
+    const layout = new NSVElement('StackLayout');
+    page.appendChild(layout);
+    expect(page.nativeView.content).toBe(layout.nativeView);
+
+    page.removeChild(layout);
+    expect(page.nativeView.content).toBeNull();
+  });
+
+  it('aggregates text nodes into the text attribute', () => {
+    const el = new NSVElement('Label');
+    const hello = new NSVText('Hello');
+    el.appendChild(hello);
+    el.appendChild(new NSVText(' world'));
+    expect(el.nativeView.text).toBe('Hello world');
+
+    hello.text = 'Bye';
+    expect(el.nativeView.text).toBe('Bye world');
+
+    el.removeChild(hello);
+    expect(el.nativeView.text).toBe(' world');
+  });
+
+  it('restores the original value when an attribute is removed', () => {
+    const el = new NSVElement('Switch');
+    expect(el.getAttribute('checked')).toBe(false);
+    el.setAttribute('checked', true);
+    el.removeAttribute('checked');
+    expect(el.getAttribute('checked')).toBe(false);
+  });
+
+  it('throws for unknown elements', () => {
+    expect(() => new NSVElement('div')).toThrow(/No known component/);
+  });
+});

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -1,0 +1,21 @@
+import { createApp, NSVElement, NSVNode, NSVRoot } from '../src';
+import type { Component } from '@vue/runtime-core';
+
+export function mount(component: Component) {
+  const root = new NSVRoot();
+  const app = createApp(component);
+  const instance = app.mount(root);
+  return { app, root, instance, el: root.el as NSVElement };
+}
+
+/** Text of the native children, in native order. */
+export function nativeChildren(el: NSVElement): string[] {
+  return el.nativeView._children.map((c: any) => c.text);
+}
+
+/** Text of the element children in NSVNode tree order (non-elements are skipped). */
+export function elementChildren(el: NSVNode): string[] {
+  return el.childNodes
+    .filter((n): n is NSVElement => n instanceof NSVElement)
+    .map((n) => n.nativeView.text);
+}

--- a/test/renderer.test.ts
+++ b/test/renderer.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest';
+import { h, nextTick, ref } from '../src';
+import { __setPlatform } from './stubs/nativescript-core';
+import { mount, nativeChildren } from './helpers';
+
+describe('renderer', () => {
+  it('mounts a component tree into native views', () => {
+    const { el } = mount({
+      render: () =>
+        h('StackLayout', [
+          h('Label', { text: 'A' }),
+          h('Label', { text: 'B' }),
+        ]),
+    });
+
+    expect(el.tagName).toBe('stacklayout');
+    expect(nativeChildren(el)).toEqual(['A', 'B']);
+  });
+
+  it('patches attributes reactively', async () => {
+    const text = ref('one');
+    const { el } = mount({ render: () => h('Label', { text: text.value }) });
+    expect(el.nativeView.text).toBe('one');
+
+    text.value = 'two';
+    await nextTick();
+    expect(el.nativeView.text).toBe('two');
+  });
+
+  it('applies platform-prefixed attributes only on the matching platform', () => {
+    __setPlatform('ios');
+    const { el } = mount({
+      render: () =>
+        h('Label', { 'ios:text': 'ios', 'android:text': 'android' }),
+    });
+    expect(el.nativeView.text).toBe('ios');
+  });
+
+  it('wires event listeners and unwires them when removed', async () => {
+    const calls: string[] = [];
+    const handler = ref<(() => void) | null>(() => calls.push('tap'));
+    const { el } = mount({
+      render: () => h('Button', { onTap: handler.value }),
+    });
+
+    el.dispatchEvent('tap');
+    expect(calls).toEqual(['tap']);
+
+    handler.value = null;
+    await nextTick();
+    el.dispatchEvent('tap');
+    expect(calls).toEqual(['tap']);
+  });
+
+  it('maps v-model to the registered prop and event', async () => {
+    const checked = ref(false);
+    const { el } = mount({
+      render: () =>
+        h('Switch', {
+          modelValue: checked.value,
+          'onUpdate:modelValue': (v: boolean) => (checked.value = v),
+        }),
+    });
+    expect(el.nativeView.checked).toBe(false);
+
+    el.nativeView.checked = true;
+    el.nativeView.notify({ eventName: 'checkedChange', object: el.nativeView });
+    expect(checked.value).toBe(true);
+  });
+
+  it('patches style objects and undoes removed properties', async () => {
+    const style = ref<Record<string, any>>({
+      color: 'red',
+      textAlign: 'center',
+    });
+    const { el } = mount({ render: () => h('Label', { style: style.value }) });
+    expect(el.nativeView.style.color).toBe('red');
+    expect(el.nativeView.style.textAlignment).toBe('center');
+
+    style.value = { color: 'blue' };
+    await nextTick();
+    expect(el.nativeView.style.color).toBe('blue');
+    expect(el.nativeView.style.textAlignment).toBeUndefined();
+  });
+
+  it('renders v-for lists', async () => {
+    const items = ref(['A', 'B', 'C']);
+    const { el } = mount({
+      render: () =>
+        h(
+          'StackLayout',
+          items.value.map((t) => h('Label', { key: t, text: t })),
+        ),
+    });
+    expect(nativeChildren(el)).toEqual(['A', 'B', 'C']);
+
+    items.value = ['A', 'C'];
+    await nextTick();
+    expect(nativeChildren(el)).toEqual(['A', 'C']);
+  });
+});

--- a/test/stubs/nativescript-core.ts
+++ b/test/stubs/nativescript-core.ts
@@ -1,0 +1,245 @@
+/**
+ * Minimal stand-in for @nativescript/core so the renderer can run under
+ * vitest. Only the surface the renderer touches is modelled: the view
+ * tree, event listeners, and the layout/content-view child APIs.
+ */
+type Listener = (...args: any[]) => void;
+
+export class ViewBase {
+  static disposeNativeViewEvent = 'disposeNativeView';
+
+  _parent: ViewBase | null = null;
+  _children: ViewBase[] = [];
+  _listeners = new Map<string, Listener[]>();
+  style: Record<string, any> = {};
+  text: any;
+  className = '';
+  [key: string]: any;
+
+  get parent() {
+    return this._parent;
+  }
+
+  get ['class']() {
+    return this.className;
+  }
+  set ['class'](v: string) {
+    this.className = v;
+  }
+
+  addEventListener(event: string, handler: Listener) {
+    const list = this._listeners.get(event) ?? [];
+    list.push(handler);
+    this._listeners.set(event, list);
+  }
+  removeEventListener(event: string, handler?: Listener) {
+    if (!handler) {
+      this._listeners.delete(event);
+      return;
+    }
+    const list = this._listeners.get(event) ?? [];
+    this._listeners.set(
+      event,
+      list.filter((h) => h !== handler),
+    );
+  }
+  on(event: string, handler: Listener) {
+    this.addEventListener(event, handler);
+  }
+  off(event: string, handler?: Listener) {
+    this.removeEventListener(event, handler);
+  }
+  once(event: string, handler: Listener) {
+    const wrapped = (...args: any[]) => {
+      this.removeEventListener(event, wrapped);
+      handler(...args);
+    };
+    this.addEventListener(event, wrapped);
+  }
+  notify(data: { eventName: string; [key: string]: any }) {
+    for (const h of [...(this._listeners.get(data.eventName) ?? [])]) {
+      h(data);
+    }
+  }
+
+  _addView(view: ViewBase, atIndex?: number) {
+    if (view._parent) {
+      throw new Error(
+        `View already has a parent. View: ${view.constructor.name} Parent: ${view._parent.constructor.name}`,
+      );
+    }
+    view._parent = this;
+    if (typeof atIndex === 'number') {
+      this._children.splice(atIndex, 0, view);
+    } else {
+      this._children.push(view);
+    }
+  }
+  _removeView(view: ViewBase) {
+    const i = this._children.indexOf(view);
+    if (i > -1) this._children.splice(i, 1);
+    view._parent = null;
+  }
+  _addChildFromBuilder(_name: string, value: any) {
+    this._addView(value);
+  }
+  _onCssStateChange() {}
+}
+
+export class View extends ViewBase {
+  showModal() {}
+  closeModal() {}
+}
+
+export class LayoutBase extends View {
+  addChild(child: View) {
+    this._addView(child);
+  }
+  insertChild(child: View, atIndex: number) {
+    this._addView(child, atIndex);
+  }
+  removeChild(child: View) {
+    this._removeView(child);
+  }
+  getChildrenCount() {
+    return this._children.length;
+  }
+  getChildAt(i: number) {
+    return this._children[i];
+  }
+}
+
+export class ContentView extends View {
+  private _content: View | null = null;
+  get content() {
+    return this._content;
+  }
+  set content(value: View | null) {
+    if (this._content) this._removeView(this._content);
+    this._content = value;
+    if (value) this._addView(value);
+  }
+}
+
+export class AbsoluteLayout extends LayoutBase {}
+export class DockLayout extends LayoutBase {}
+export class FlexboxLayout extends LayoutBase {}
+export class GridLayout extends LayoutBase {}
+export class RootLayout extends LayoutBase {}
+export class StackLayout extends LayoutBase {}
+export class WrapLayout extends LayoutBase {}
+export class ScrollView extends ContentView {}
+export class Page extends ContentView {
+  actionBar: any;
+}
+
+export class Frame extends View {
+  static _topmost: Frame | null = null;
+  static topmost() {
+    return Frame._topmost;
+  }
+  static getFrameById() {
+    return null;
+  }
+  currentPage: any;
+  currentEntry: any = {};
+  navigate(entry: any) {
+    this.currentPage = entry.create();
+    this.currentEntry = entry;
+  }
+  replacePage() {}
+  canGoBack() {
+    return false;
+  }
+  goBack() {}
+}
+
+export class ActionBar extends View {
+  navigationButton: any = null;
+  titleView: any = null;
+  actionItems = {
+    _items: [] as any[],
+    getItems() {
+      return [...this._items];
+    },
+    setItems(items: any[]) {
+      this._items = [...items];
+    },
+    addItem(item: any) {
+      this._items.push(item);
+    },
+    removeItem(item: any) {
+      this._items = this._items.filter((i) => i !== item);
+    },
+  };
+}
+export class ActionItem extends View {}
+export class NavigationButton extends ActionItem {}
+export class TabView extends View {
+  items: any[] | undefined;
+}
+export class TabViewItem extends View {}
+export class FormattedString extends View {
+  spans: any[] = [];
+}
+export class Span extends View {}
+export class ListView extends View {
+  items: any;
+  itemTemplates: any;
+  itemTemplateSelector: any;
+  refresh() {
+    this.refreshCount = (this.refreshCount ?? 0) + 1;
+  }
+}
+export class ObservableArray<T = any> extends Array<T> {
+  getItem(i: number) {
+    return this[i];
+  }
+}
+
+export class HtmlView extends View {}
+export class WebView extends View {}
+export class ActivityIndicator extends View {}
+export class Button extends View {}
+export class DatePicker extends View {}
+export class Image extends View {}
+export class Label extends View {}
+export class ListPicker extends View {}
+export class Placeholder extends View {}
+export class Progress extends View {}
+export class ProxyViewContainer extends LayoutBase {}
+export class SearchBar extends View {}
+export class SegmentedBar extends View {}
+export class SegmentedBarItem extends View {}
+export class Slider extends View {}
+export class Switch extends View {
+  checked = false;
+}
+export class TextField extends View {}
+export class TextView extends View {}
+export class TimePicker extends View {}
+
+export let isAndroid = false;
+export let isIOS = true;
+export function __setPlatform(platform: 'android' | 'ios') {
+  isAndroid = platform === 'android';
+  isIOS = platform === 'ios';
+}
+
+export const Application = {
+  _rootView: null as View | null,
+  run(entry: { create(): View }) {
+    this._rootView = entry.create();
+  },
+  resetRootView(entry: { create(): View }) {
+    this._rootView = entry.create();
+  },
+  getRootView() {
+    return this._rootView;
+  },
+};
+
+export type EventData = { eventName: string; object: any };
+export type ItemEventData = any;
+export type NavigationEntry = any;
+export type ShowModalOptions = any;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from 'vitest/config';
+import { fileURLToPath } from 'node:url';
+
+export default defineConfig({
+  define: {
+    __DEV__: true,
+  },
+  resolve: {
+    alias: {
+      '@nativescript/core': fileURLToPath(
+        new URL('./test/stubs/nativescript-core.ts', import.meta.url),
+      ),
+    },
+  },
+  test: {
+    include: ['test/**/*.test.ts'],
+  },
+});


### PR DESCRIPTION
Stacked on #1122.

## What
- **CI workflow** (`.github/workflows/ci.yml`): typecheck, prettier, vitest, build, and `npm pack --dry-run` for both published packages, on Node 20 and 24. Runs on `pull_request`, pushes to `main`, and merge queues. `permissions: contents: read`, `persist-credentials: false`, actions pinned by commit SHA. Fork PRs get only a read-only token and no secrets by construction.
- **Release workflow** (`.github/workflows/release.yml`): on `v*` tags, verifies the tag matches every package version, runs the checks, then **stages** `nativescript-vue` and `@nativescript-vue/template-blank` on npm with `npm stage publish --provenance`, using npm trusted publishing (OIDC, no token anywhere) from the `npm` environment, and creates a **draft** GitHub release. Nothing goes live from CI: the trusted publisher only grants stage-publish, and a maintainer approves each staged version with 2FA (`npm stage approve`), which is what publishes it. The job summary lists the exact commands. Prerelease versions go to the `next` dist-tag.
- **Release script** (`npm run release -- 3.1.0`): bumps root, template-blank and the StackBlitz template's `nativescript-vue` pin together, commits `release: x.y.z`, tags. Pushing the tag triggers staging. Documented in `CONTRIBUTING.md`, including the approve step (runtime before template, since the template pins the exact runtime version).
- **Dependabot** for actions and npm, grouped.
- **Tests**: vitest with a stub of `@nativescript/core` (`test/stubs/nativescript-core.ts`) so the renderer runs in Node. 14 baseline tests for DOM tree ops, attribute/event/style/v-model patching and v-for. Later branches in the stack add regression tests here.
- **Refactor**: element resolvers used `require('@nativescript/core')` inside ESM, which bypassed the test alias (and any bundler alias). Replaced with a namespace import; core was already imported eagerly by the same module.

## One-time setup outside this PR
1. **npm trusted publishing** for both packages: repo `nativescript-vue/nativescript-vue`, workflow `release.yml`, environment `npm`, permission **stage publish only**. Done for `nativescript-vue`; still needed for `@nativescript-vue/template-blank`.
2. Per package, under package access: "Require two-factor authentication and disallow tokens".
3. **Environment `npm`** in repo Settings → Environments (required reviewers optional now that approval happens on npm with 2FA).
4. Settings → Actions → General: workflow permissions "Read repository contents", "Require approval for all external contributors", and "Require actions to be pinned to a full-length commit SHA".

`npm stage publish` needs npm ≥ 11.19; the job upgrades npm to latest. Not exercised end to end yet; the first real tag is the proof, and a failure there stops before the draft release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)