### PR TITLE
fix(dom): keep child order stable on keyed reorders

### DIFF
--- a/src/dom/index.ts
+++ b/src/dom/index.ts
@@ -60,12 +60,11 @@ export abstract class NSVNode {
       return null;
     }
 
-    const selfIndex = this.parentNode.childNodes.findIndex(
-      (n) => n.nodeId === this.nodeId,
-    );
+    const siblings = this.parentNode.childNodes;
+    const selfIndex = siblings.indexOf(this);
 
-    if (selfIndex > -1 && selfIndex < this.parentNode.childNodes.length - 1) {
-      return this.parentNode.childNodes[selfIndex + 1];
+    if (selfIndex > -1 && selfIndex < siblings.length - 1) {
+      return siblings[selfIndex + 1];
     }
 
     return null;
@@ -76,12 +75,11 @@ export abstract class NSVNode {
       return null;
     }
 
-    const selfIndex = this.parentNode.childNodes.findIndex(
-      (n) => n.nodeId === this.nodeId,
-    );
+    const siblings = this.parentNode.childNodes;
+    const selfIndex = siblings.indexOf(this);
 
     if (selfIndex > 0) {
-      return this.parentNode.childNodes[selfIndex - 1];
+      return siblings[selfIndex - 1];
     }
 
     return null;
@@ -207,37 +205,38 @@ export class NSVElement extends NSVNode {
   }
 
   insertBefore(el: NSVNode, anchor?: NSVNode | null) {
-    if (!anchor) {
+    if (!anchor || anchor === el) {
       return this.appendChild(el);
     }
 
-    const refIndex = this.childNodes.findIndex(
-      (node) => node.nodeId === anchor.nodeId,
-    );
+    // Detach before locating the anchor: when el is already a child of this
+    // node and sits before the anchor, removing it shifts the anchor's index.
+    el.parentNode?.removeChild(el);
+
+    const refIndex = this.childNodes.indexOf(anchor);
 
     if (refIndex === -1) {
       return this.appendChild(el);
     }
 
-    if (el.parentNode) {
-      el.parentNode.removeChild(el);
-    }
-
     this.childNodes.splice(refIndex, 0, el);
     el.parentNode = this;
 
-    // find index to use for the native view, since non-visual nodes
-    // (comment/text don't exist in the native view hierarchy)
-    // todo: potentially refactor based on my benchmark:
-    // https://www.measurethat.net/Benchmarks/Show/7450/0/filter-findindex
-    const trueIndex = this.childNodes
-      .filter((node) => node.nodeType === NSVNodeTypes.ELEMENT)
-      .findIndex((node) => node.nodeId === el.nodeId);
+    // comment/text nodes don't exist in the native view hierarchy, so the
+    // native index only counts the element nodes preceding el
+    let trueIndex = 0;
+    for (let i = 0; i < refIndex; i++) {
+      if (this.childNodes[i].nodeType === NSVNodeTypes.ELEMENT) {
+        trueIndex++;
+      }
+    }
 
     this.addChild(el, trueIndex);
   }
 
   appendChild(el: NSVNode) {
+    el.parentNode?.removeChild(el);
+
     this.childNodes.push(el);
     el.parentNode = this;
 
@@ -245,9 +244,7 @@ export class NSVElement extends NSVNode {
   }
 
   removeChild(el: NSVNode) {
-    const index = this.childNodes.findIndex(
-      (node) => node.nodeId === el.nodeId,
-    );
+    const index = this.childNodes.indexOf(el);
 
     if (index > -1) {
       this.childNodes.splice(index, 1);
@@ -315,8 +312,8 @@ export class NSVRoot extends NSVNode {
   }
 
   removeChild(el: NSVNode) {
-    // console.log('NSVRoot->removeCchild()');
     if (el === this.el) {
+      el.parentNode = null;
       this.el = null;
     }
   }

--- a/test/renderer.test.ts
+++ b/test/renderer.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { h, nextTick, ref } from '../src';
 import { __setPlatform } from './stubs/nativescript-core';
-import { mount, nativeChildren } from './helpers';
+import { elementChildren, mount, nativeChildren } from './helpers';
 
 describe('renderer', () => {
   it('mounts a component tree into native views', () => {
@@ -97,5 +97,56 @@ describe('renderer', () => {
     items.value = ['A', 'C'];
     await nextTick();
     expect(nativeChildren(el)).toEqual(['A', 'C']);
+  });
+});
+
+describe('keyed reorders', () => {
+  function mountList(initial: string[]) {
+    const items = ref(initial);
+    const { el } = mount({
+      render: () =>
+        h(
+          'StackLayout',
+          items.value.map((t) => h('Label', { key: t, text: t })),
+        ),
+    });
+    return {
+      el,
+      async set(next: string[]) {
+        items.value = next;
+        await nextTick();
+        expect(nativeChildren(el)).toEqual(next);
+        expect(elementChildren(el)).toEqual(next);
+      },
+    };
+  }
+
+  it('moves an item to the end and keeps later appends after it', async () => {
+    const list = mountList(['A', 'B', 'C', 'D']);
+    await list.set(['B', 'C', 'D', 'A']);
+    await list.set(['B', 'C', 'D', 'A', 'E']);
+  });
+
+  it('moves an item forward past its siblings', async () => {
+    const list = mountList(['A', 'B', 'C', 'D']);
+    await list.set(['B', 'C', 'A', 'D']);
+    await list.set(['B', 'A', 'C', 'D']);
+  });
+
+  it('reverses and shuffles', async () => {
+    const list = mountList(['A', 'B', 'C', 'D', 'E']);
+    await list.set(['E', 'D', 'C', 'B', 'A']);
+    await list.set(['C', 'A', 'E', 'B', 'D']);
+    await list.set(['A', 'B', 'C', 'D', 'E']);
+  });
+
+  it('keeps sibling lookups consistent after moves', async () => {
+    const list = mountList(['A', 'B', 'C']);
+    await list.set(['B', 'C', 'A']);
+    const [b, c, a] = list.el.childNodes.filter(
+      (n) => n.nodeType === 'element',
+    );
+    expect(a.prevSibling).toBe(c);
+    expect(b.nextSibling).toBe(c);
   });
 });


### PR DESCRIPTION
Stacked on #1123.

## Bug
`NSVElement.insertBefore` computed the anchor's index, then detached the moved node from its parent. When the node was already a child sitting *before* the anchor (which is exactly what Vue's keyed diff does when an item moves toward the end), the detach shifted the anchor's index and the node landed one slot too late. The native view happened to come out right when the anchor was a v-for fragment marker, but the `childNodes` order was wrong, so the **next append rendered before the moved item**. `appendChild` never detached at all.

Reproduction (now a test): render `[A, B, C, D]`, set `[B, C, D, A]`, then `[B, C, D, A, E]`. Native order was `B C D E A`.

## Fix
- Detach first, then locate the anchor; `appendChild` also detaches.
- `nextSibling`, `prevSibling`, `removeChild` and `insertBefore` compare by identity instead of scanning for `nodeId`, and the native index is computed in a single pass instead of `filter().findIndex()`.
- `NSVRoot.removeChild` clears `parentNode` on the removed element.

## Tests
Four keyed-reorder cases (move to end + append, move forward, reverse/shuffle, sibling lookups after moves). All fail on the previous `src/dom/index.ts` and pass now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)