### PR TITLE
fix(ListView): refresh on in-place array mutations

### DIFF
--- a/src/components/ListView.ts
+++ b/src/components/ListView.ts
@@ -68,8 +68,9 @@ export const ListView = /*#__PURE__*/ defineComponent({
 
     const vm = getCurrentInstance();
 
-    watch(props, () => {
+    function refresh() {
       try {
+        // ObservableArray notifies the native ListView of changes itself
         if (props.items instanceof ObservableArray) {
           return;
         }
@@ -79,7 +80,12 @@ export const ListView = /*#__PURE__*/ defineComponent({
       } catch (err) {
         console.error('Error while refreshing ListView', err);
       }
-    });
+    }
+
+    // depth 1 tracks the array's length and slots without walking into the
+    // items themselves; cells re-render on their own when item fields change
+    watch(() => props.items, refresh, { deep: 1 });
+    watch(() => props.itemTemplateSelector, refresh);
 
     let cellId = 0;
     interface ItemCellData {

--- a/test/listview.test.ts
+++ b/test/listview.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { h, nextTick, reactive, ref, ListView } from '../src';
+import { ObservableArray } from './stubs/nativescript-core';
+import { mount } from './helpers';
+
+describe('ListView', () => {
+  it('refreshes when a reactive array is mutated in place', async () => {
+    const items = reactive(['A', 'B']);
+    const { el } = mount({ render: () => h(ListView, { items }) });
+    expect(el.nativeView.refreshCount).toBeUndefined();
+
+    items.push('C');
+    await nextTick();
+    expect(el.nativeView.refreshCount).toBe(1);
+
+    items.splice(0, 1);
+    await nextTick();
+    expect(el.nativeView.refreshCount).toBe(2);
+  });
+
+  it('refreshes when the items array is replaced', async () => {
+    const items = ref(['A']);
+    const { el } = mount({ render: () => h(ListView, { items: items.value }) });
+
+    items.value = ['B'];
+    await nextTick();
+    expect(el.nativeView.refreshCount).toBe(1);
+  });
+
+  it('leaves refreshing to ObservableArray', async () => {
+    const items = ref(new ObservableArray('A'));
+    const { el } = mount({ render: () => h(ListView, { items: items.value }) });
+
+    items.value.push('B');
+    await nextTick();
+    expect(el.nativeView.refreshCount).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Stacked on #1124.

## Bug
`ListView` used `watch(props, ...)` to call `refresh()` on the native list. Vue 3.5 changed `watch` on a shallow-reactive source (which component `props` are) to a depth-one traversal, so the watcher only sees the `items` reference, not its contents. `items.push(x)` or `items.splice(...)` on a plain reactive array no longer refreshes the list. Verified against `@vue/runtime-core` 3.5.42: a push fires the old watcher 0 times.

## Fix
Watch `() => props.items` with `deep: 1`, which tracks the array's slots and length without walking into each item (cells already re-render on their own when item fields change), and watch `itemTemplateSelector` separately. The `ObservableArray` early return is kept, since it notifies the native list itself.

## Tests
`test/listview.test.ts`: in-place push/splice, array replacement, ObservableArray left alone. The first case fails on the previous code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)