### PR TITLE
fix: register the root app before mounting it

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -87,10 +87,13 @@ export const createApp = ((...args) => {
   };
 
   app.start = () => {
+    // mounted hooks run synchronously inside mount, and $navigateTo/$showModal
+    // called from them need the root app context
+    setRootApp(app);
+
     const componentInstance = app.mount(createAppRoot(), false, false);
 
     startApp(componentInstance);
-    setRootApp(app);
 
     return componentInstance;
   };

--- a/test/navigation.test.ts
+++ b/test/navigation.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { $navigateTo, createApp, h, onMounted } from '../src';
+import { Frame } from './stubs/nativescript-core';
+
+const Details = { render: () => h('Page', [h('Label', { text: 'details' })]) };
+
+describe('$navigateTo', () => {
+  it('can be called from the root component mounted hook', () => {
+    const frame = new Frame();
+    Frame._topmost = frame;
+
+    const App = {
+      setup() {
+        onMounted(() => {
+          $navigateTo(Details);
+        });
+        return () => h('Frame');
+      },
+    };
+
+    expect(() => createApp(App).start()).not.toThrow();
+    expect(frame.currentPage?.content?.text).toBe('details');
+  });
+});


### PR DESCRIPTION
Stacked on #1126.

## Bug
`app.start()` called `setRootApp(app)` after `app.mount(...)`. Vue runs mounted hooks synchronously inside `mount`, so a root component that calls `$navigateTo` or `$showModal` from `onMounted` (a common "redirect to login" pattern) hit `createNativeView`, which reads `rootApp._context`, while `rootApp` was still null: `TypeError: Cannot read properties of null`.

## Fix
Set the root app before mounting.

## Tests
`test/navigation.test.ts`: root component navigating from `onMounted`. Throws on the previous code, passes now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)