### PR TITLE
fix: honor index 0 when inserting ActionItems, Spans and TabViewItems

### DIFF
--- a/src/components/ActionBar.ts
+++ b/src/components/ActionBar.ts
@@ -19,7 +19,7 @@ registerElement('NSCActionBar', () => NSCActionBar, {
       if (childView instanceof NSCNavigationButton) {
         actionBar.navigationButton = childView;
       } else if (childView instanceof NSCActionItem) {
-        if (atIndex) {
+        if (typeof atIndex === 'number') {
           const ai: NSCActionItem[] = actionBar.actionItems.getItems();
           ai.splice(atIndex, 0, childView);
           (actionBar.actionItems as any).setItems(ai);

--- a/src/nativescript/elements.ts
+++ b/src/nativescript/elements.ts
@@ -93,7 +93,7 @@ export function registerCoreElements() {
   registerElement('FormattedString', () => NSCore.FormattedString, {
     nodeOps: {
       insert(child, parent, atIndex) {
-        if (atIndex) {
+        if (typeof atIndex === 'number') {
           parent.nativeView.spans.splice(atIndex, 0, child.nativeView);
           return;
         }
@@ -172,18 +172,21 @@ export function registerCoreElements() {
       event: 'selectedIndexChange',
     },
     nodeOps: {
-      insert(child, parent) {
+      insert(child, parent, atIndex) {
         const tabView = parent.nativeView as NSCTabView;
 
         if (child.nativeView instanceof NSCTabViewItem) {
-          const items = tabView.items || [];
+          const items = [...(tabView.items || [])];
+          items.splice(atIndex ?? items.length, 0, child.nativeView);
 
-          parent.setAttribute('items', items.concat([child.nativeView]));
+          parent.setAttribute('items', items);
         }
       },
       remove(child, parent) {
         const tabView = parent.nativeView as NSCTabView;
-        const items = tabView.items.filter((item) => item !== child.nativeView);
+        const items = (tabView.items || []).filter(
+          (item) => item !== child.nativeView,
+        );
 
         parent.setAttribute('items', items);
       },

--- a/test/insert-index.test.ts
+++ b/test/insert-index.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import { ActionBar, h, nextTick, ref } from '../src';
+import { mount } from './helpers';
+
+describe('inserting a child at index 0', () => {
+  it('keeps ActionItems in template order', async () => {
+    const showFirst = ref(false);
+    const { el } = mount({
+      render: () =>
+        h('Page', [
+          h(ActionBar, null, () => [
+            showFirst.value ? h('ActionItem', { key: 'a', text: 'A' }) : null,
+            h('ActionItem', { key: 'b', text: 'B' }),
+          ]),
+        ]),
+    });
+    const actionBar = el.nativeView.actionBar;
+    const titles = () =>
+      actionBar.actionItems.getItems().map((i: any) => i.text);
+    expect(titles()).toEqual(['B']);
+
+    showFirst.value = true;
+    await nextTick();
+    expect(titles()).toEqual(['A', 'B']);
+  });
+
+  it('keeps Spans in template order', async () => {
+    const showFirst = ref(false);
+    const { el } = mount({
+      render: () =>
+        h('Label', [
+          h('FormattedString', [
+            showFirst.value ? h('Span', { key: 'a', text: 'a' }) : null,
+            h('Span', { key: 'b', text: 'b' }),
+          ]),
+        ]),
+    });
+    const spans = () =>
+      el.nativeView._children[0].spans.map((s: any) => s.text);
+    expect(spans()).toEqual(['b']);
+
+    showFirst.value = true;
+    await nextTick();
+    expect(spans()).toEqual(['a', 'b']);
+  });
+
+  it('keeps TabViewItems in template order', async () => {
+    const showFirst = ref(false);
+    const { el } = mount({
+      render: () =>
+        h('TabView', [
+          showFirst.value ? h('TabViewItem', { key: 'a', title: 'A' }) : null,
+          h('TabViewItem', { key: 'b', title: 'B' }),
+        ]),
+    });
+    const titles = () => el.nativeView.items.map((i: any) => i.title);
+    expect(titles()).toEqual(['B']);
+
+    showFirst.value = true;
+    await nextTick();
+    expect(titles()).toEqual(['A', 'B']);
+  });
+});


### PR DESCRIPTION
Stacked on #1127.

## Bug
The `ActionBar` and `FormattedString` node ops checked `if (atIndex)`, so an index of `0` fell through to append. A first `<ActionItem v-if>` or `<Span v-if>` toggled on after its siblings rendered at the end. `TabView`'s insert ignored the index altogether.

## Fix
Check `typeof atIndex === 'number'`; TabView splices at the given index.

## Tests
`test/insert-index.test.ts`: all three cases fail on the previous code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)