### PR TITLE
fix: only treat on + non-lowercase keys as event listeners

### DIFF
--- a/src/components/ListView.ts
+++ b/src/components/ListView.ts
@@ -94,7 +94,7 @@ export const ListView = /*#__PURE__*/ defineComponent({
     }
     const cells = ref<Record<string, ItemCellData>>({});
 
-    function onitemLoading(event: ItemEventData) {
+    function onItemLoading(event: ItemEventData) {
       const el = event.view?.[ELEMENT_REF] as NSVElement;
       const id = el?.nativeView[LIST_CELL_ID] ?? `LIST_CELL_${cellId++}`;
 
@@ -170,7 +170,7 @@ export const ListView = /*#__PURE__*/ defineComponent({
           items: props.items,
           itemTemplates,
           itemTemplateSelector,
-          onitemLoading,
+          onItemLoading,
         },
         cellVNODES(),
       );

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,7 +36,7 @@ export * from './components';
 export * from './dom';
 export * from './registry';
 export * from './renderer';
-export { createNativeView, ELEMENT_REF } from './runtimeHelpers';
+export { createNativeView, ELEMENT_REF, isOn } from './runtimeHelpers';
 
 export * from '@vue/runtime-core';
 export { vShow } from './directives/vShow';

--- a/src/renderer/modules/events.ts
+++ b/src/renderer/modules/events.ts
@@ -66,7 +66,6 @@ function parseName(name: string): [string, EventListenerOptions | undefined] {
     while ((m = name.match(optionsModifierRE))) {
       name = name.slice(0, name.length - m[0].length);
       (options as any)[m[0].toLowerCase()] = true;
-      options;
     }
   }
 

--- a/src/runtimeHelpers.ts
+++ b/src/runtimeHelpers.ts
@@ -80,7 +80,9 @@ export function createNativeView<T = View, P = any>(
 
 export const ELEMENT_REF = Symbol(__DEV__ ? `elementRef` : ``);
 
-const onRE = /^on.+/;
+// matches Vue's own isOn: "on" followed by anything but a lowercase letter,
+// so onTap and on:textChange are events while onboardingTitle is a prop
+const onRE = /^on[^a-z]/;
 export const isOn = (key: string) => onRE.test(key);
 
 export const isAndroidKey = (key: string) => key.startsWith('android:');

--- a/test/events.test.ts
+++ b/test/events.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { h, isOn } from '../src';
+import { mount } from './helpers';
+
+describe('event key detection', () => {
+  it('treats on + uppercase and on: as events, other on-prefixed keys as props', () => {
+    expect(isOn('onTap')).toBe(true);
+    expect(isOn('on:textChange')).toBe(true);
+    expect(isOn('onboardingTitle')).toBe(false);
+    expect(isOn('online')).toBe(false);
+  });
+
+  it('sets on-prefixed props as attributes instead of listeners', () => {
+    const { el } = mount({
+      render: () => h('Label', { onboardingTitle: 'hi', online: true }),
+    });
+    expect(el.nativeView.onboardingTitle).toBe('hi');
+    expect(el.nativeView.online).toBe(true);
+    expect(el.nativeView._listeners.size).toBe(0);
+  });
+
+  it('honors the Once modifier', () => {
+    let calls = 0;
+    const { el } = mount({
+      render: () => h('Button', { onTapOnce: () => calls++ }),
+    });
+    el.dispatchEvent('tap');
+    el.dispatchEvent('tap');
+    expect(calls).toBe(1);
+  });
+});

--- a/test/listview.test.ts
+++ b/test/listview.test.ts
@@ -36,3 +36,28 @@ describe('ListView', () => {
     expect(el.nativeView.refreshCount).toBeUndefined();
   });
 });
+
+describe('ListView cells', () => {
+  it('renders the slot template for each loaded item', () => {
+    const { el } = mount({
+      render: () =>
+        h(
+          ListView,
+          { items: ['A', 'B'] },
+          {
+            default: ({ item, index }: { item: string; index: number }) =>
+              h('Label', { text: `${index}:${item}` }),
+          },
+        ),
+    });
+    expect(el.nativeView._listeners.has('itemLoading')).toBe(true);
+
+    const event: any = {
+      eventName: 'itemLoading',
+      object: el.nativeView,
+      index: 1,
+    };
+    el.nativeView.notify(event);
+    expect(event.view?.text).toBe('1:B');
+  });
+});


### PR DESCRIPTION
Stacked on #1128.

## Bug
`isOn` was `/^on.+/`, so any prop starting with "on" (`onboardingTitle`, `online`, ...) was routed to `patchEvent` and attached as a native listener for a bogus event instead of being set on the view. Vue's own check is `on` followed by a non-lowercase character.

## Fix
Match Vue's rule. `onTap` and the internal `on:textChange` form still count as events. Also drops a stray no-op statement in `parseName` and exports `isOn` for tests/plugins.

## Tests
`test/events.test.ts`: key classification, on-prefixed props set as attributes, `.once` modifier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)