### PR TITLE
feat: warn in dev on unsupported v-model, Frame and KeepAlive usage

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -42,7 +42,7 @@ export * from '@vue/runtime-core';
 export { vShow } from './directives/vShow';
 export { $closeModal, $showModal } from './plugins/modals';
 export { $navigateBack, $navigateTo } from './plugins/navigation';
-export * from './renderer/runtimeDomOverrides';
+export { KeepAlive, TransitionGroup } from './renderer/runtimeDomOverrides';
 
 // creates a special root container that calls resetRoot whenever it's children change
 function createAppRoot() {

--- a/src/nativescript/elements.ts
+++ b/src/nativescript/elements.ts
@@ -68,8 +68,18 @@ export function registerCoreElements() {
         }
       },
       remove(child: NSVElement, parent: NSVElement): void {
-        // ignore? warn? throw? navigate back?
-        // console.log("REMOVE CHILD FROM FRAME", child);
+        // a Page removed by Vue stays on the native backstack; navigation
+        // out of a Frame is only driven through $navigateBack / frame APIs
+        if (__DEV__) {
+          const frame = parent.nativeView as NSCFrame;
+          if (frame.currentPage === child.nativeView) {
+            logger.warn(
+              `Removing the current <Page> from a <Frame> has no effect on ` +
+                `the native navigation stack. Use $navigateBack() or ` +
+                `$navigateTo() instead of v-if/v-for on <Page>.`,
+            );
+          }
+        }
       },
     },
   });

--- a/src/renderer/patchProp.ts
+++ b/src/renderer/patchProp.ts
@@ -6,6 +6,7 @@ import { patchStyle } from './modules/style';
 
 import { getViewMeta, NSVModelDescriptor } from '../registry';
 import { isOn } from '../runtimeHelpers';
+import { logger } from '../util/logger';
 
 import type {
   ComponentInternalInstance,
@@ -32,21 +33,30 @@ export const patchProp: RendererOptions['patchProp'] = (
       patchStyle(el, prevValue, nextValue);
       break;
     case 'modelValue':
-    case 'onUpdate:modelValue':
-      try {
-        // v-model - maps modelValue/onUpdate:modelValue to the correct prop/events from the registry meta
-        const { prop, event } = getViewMeta(el.tagName)
-          .model as NSVModelDescriptor;
-        if (key === 'modelValue') {
-          patchAttr(el, prop, prevValue, nextValue);
-        } else {
-          const cb = nextValue
-            ? ($event) => nextValue($event.object[prop])
-            : nextValue;
-          patchEvent(el, `on:${event}`, prevValue, cb);
-        }
-      } catch (err) {
-        // ignore if the view meta can't be found.
+    case 'onUpdate:modelValue': {
+      // v-model maps modelValue/onUpdate:modelValue to the prop/event pair
+      // declared in the element's registry meta
+      const model = resolveModel(el);
+      if (!model) {
+        break;
+      }
+      if (key === 'modelValue') {
+        patchAttr(el, model.prop, prevValue, nextValue);
+      } else {
+        const cb = nextValue
+          ? ($event) => nextValue($event.object[model.prop])
+          : nextValue;
+        patchEvent(el, `on:${model.event}`, prevValue, cb);
+      }
+      break;
+    }
+    case 'modelModifiers':
+      if (__DEV__ && nextValue && Object.keys(nextValue).length) {
+        logger.warn(
+          `v-model modifiers (.${Object.keys(nextValue).join(', .')}) are ` +
+            `not supported on <${el.tagName}>; apply the transformation in ` +
+            `a computed setter instead.`,
+        );
       }
       break;
     default:
@@ -57,3 +67,20 @@ export const patchProp: RendererOptions['patchProp'] = (
       }
   }
 };
+
+function resolveModel(el: NSVElement): NSVModelDescriptor | undefined {
+  let model: NSVModelDescriptor | undefined;
+  try {
+    model = getViewMeta(el.tagName).model;
+  } catch {
+    // unregistered element, fall through to the warning
+  }
+  if (!model && __DEV__) {
+    logger.warn(
+      `v-model is not supported on <${el.tagName}>: no model prop/event ` +
+        `pair is registered for it. Pass { model: { prop, event } } to ` +
+        `registerElement() to enable it.`,
+    );
+  }
+  return model;
+}

--- a/src/renderer/runtimeDomOverrides.ts
+++ b/src/renderer/runtimeDomOverrides.ts
@@ -1,3 +1,4 @@
+import { defineComponent } from '@vue/runtime-core';
 import { logger } from '../util/logger';
 
 export const TransitionGroup = {
@@ -6,3 +7,22 @@ export const TransitionGroup = {
     return { $props: {} };
   },
 };
+
+let warnedKeepAlive = false;
+
+/**
+ * KeepAlive needs a detached container to park deactivated subtrees in,
+ * which has no native equivalent. Render the content without caching.
+ */
+export const KeepAlive = /*#__PURE__*/ defineComponent({
+  name: 'KeepAlive',
+  setup(_props, { slots }) {
+    if (__DEV__ && !warnedKeepAlive) {
+      warnedKeepAlive = true;
+      logger.warn(
+        'KeepAlive is not supported; its children are rendered without caching.',
+      );
+    }
+    return () => slots.default?.();
+  },
+});

--- a/test/warnings.test.ts
+++ b/test/warnings.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { h, KeepAlive, nextTick, ref } from '../src';
+import { mount } from './helpers';
+
+const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+afterEach(() => warn.mockClear());
+
+const warnings = () => warn.mock.calls.map((c) => String(c[0]));
+
+describe('dev warnings', () => {
+  it('warns when v-model is used on an element without model meta', () => {
+    mount({ render: () => h('Label', { modelValue: 'x' }) });
+    expect(warnings()).toEqual([
+      expect.stringMatching(/v-model is not supported on <label>/),
+    ]);
+  });
+
+  it('warns about unsupported v-model modifiers', () => {
+    mount({
+      render: () =>
+        h('TextField', { modelValue: 'x', modelModifiers: { trim: true } }),
+    });
+    expect(warnings()).toEqual([expect.stringMatching(/modifiers \(\.trim\)/)]);
+  });
+
+  it('warns when the current Page is removed from a Frame', async () => {
+    const show = ref(true);
+    mount({
+      render: () => h('Frame', [show.value ? h('Page', { key: 'a' }) : null]),
+    });
+    expect(warnings()).toEqual([]);
+
+    show.value = false;
+    await nextTick();
+    expect(warnings()).toEqual([
+      expect.stringMatching(/Removing the current <Page>/),
+    ]);
+  });
+
+  it('renders KeepAlive children without caching and warns once', () => {
+    const { el } = mount({
+      render: () => h(KeepAlive, null, () => h('Label', { text: 'kept' })),
+    });
+    expect(el.nativeView.text).toBe('kept');
+    expect(warnings()).toEqual([
+      expect.stringMatching(/KeepAlive is not supported/),
+    ]);
+
+    mount({ render: () => h(KeepAlive, null, () => h('Label')) });
+    expect(warnings()).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
Stacked on #1129.

Turns four silent failure modes into development warnings with predictable behaviour:

- **`v-model` on an element without model meta** (e.g. a plugin element registered without `{ model }`): previously swallowed by a `try/catch` so nothing happened. Now warns and explains how to register the prop/event pair.
- **`v-model` modifiers** (`.trim`, `.number`, `.lazy`): previously leaked a `modelModifiers` object onto the native view and were ignored. Now warns; the property is no longer set.
- **Removing the current `<Page>` from a `<Frame>`** via `v-if`/`v-for`: the node op was an empty stub, so the native backstack was left untouched. Warns (only when the removed page is the frame's current page, so unmounting a whole tree stays quiet).
- **`KeepAlive`**: re-exported from runtime-core but crashed with "No known component for element div" because it creates a detached container. Here it is replaced by an override that renders the slot without caching and warns once. `index.ts` re-exports the overrides by name so they take precedence over the runtime-core star export. **Superseded by #1139**, which wraps the real `KeepAlive` and supports it properly; this PR keeps the stopgap only so the stack stays bisectable.

## Tests
`test/warnings.test.ts` covers all four.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
