### PR TITLE
perf: diff style patches instead of clearing and reapplying

### DIFF
--- a/src/renderer/modules/style.ts
+++ b/src/renderer/modules/style.ts
@@ -61,7 +61,10 @@ function addStyleProperty(el: NSVElement, property: string, value: any) {
     _sov.set(property, el.style[property]);
   }
 
-  el.style[property] = value;
+  // every style write re-evaluates the native CSS state, so skip no-ops
+  if (el.style[property] !== value) {
+    el.style[property] = value;
+  }
 }
 
 function removeStyleProperty(el: NSVElement, property: string) {
@@ -88,23 +91,19 @@ function removeStyleProperty(el: NSVElement, property: string) {
   }
 }
 
-// todo: perhaps mimic dom version with prefixing stripped out: https://github.com/vuejs/core/blob/main/packages/runtime-dom/src/modules/style.ts
 export function patchStyle(el: NSVElement, prev: Style, next: Style) {
-  if (prev) {
-    const style = normalizeStyle(prev);
-    // undo old styles
-    Object.keys(style).forEach((property) => {
+  const prevStyle = normalizeStyle(prev) ?? {};
+  const nextStyle = normalizeStyle(next) ?? {};
+
+  for (const property in prevStyle) {
+    if (!(property in nextStyle)) {
       removeStyleProperty(el, property);
-    });
+    }
   }
 
-  if (!next) {
-    el.removeAttribute('style');
-  } else {
-    // set new styles
-    const style = normalizeStyle(next);
-    Object.keys(style).forEach((property) => {
-      addStyleProperty(el, property, style[property]);
-    });
+  // next is applied in full rather than diffed against prev: Vue passes the
+  // same object for both when a reactive style object is mutated in place
+  for (const property in nextStyle) {
+    addStyleProperty(el, property, nextStyle[property]);
   }
 }

--- a/test/renderer.test.ts
+++ b/test/renderer.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { h, nextTick, ref } from '../src';
+import { h, nextTick, reactive, ref } from '../src';
 import { __setPlatform } from './stubs/nativescript-core';
 import { elementChildren, mount, nativeChildren } from './helpers';
 
@@ -148,5 +148,51 @@ describe('keyed reorders', () => {
     );
     expect(a.prevSibling).toBe(c);
     expect(b.nextSibling).toBe(c);
+  });
+});
+
+describe('style patching', () => {
+  function countingStyle(el: any) {
+    const writes: string[] = [];
+    el.nativeView.style = new Proxy(el.nativeView.style, {
+      set(target, prop, value) {
+        writes.push(String(prop));
+        target[prop as string] = value;
+        return true;
+      },
+    });
+    return writes;
+  }
+
+  it('only writes properties that changed or were removed', async () => {
+    const style = ref<Record<string, any>>({ color: 'red', fontSize: 10 });
+    const { el } = mount({ render: () => h('Label', { style: style.value }) });
+    const writes = countingStyle(el);
+
+    style.value = { color: 'red', fontSize: 12 };
+    await nextTick();
+    expect(writes).toEqual(['fontSize']);
+
+    style.value = { fontSize: 12 };
+    await nextTick();
+    expect(writes).toEqual(['fontSize', 'color']);
+    expect(el.nativeView.style.color).toBeUndefined();
+  });
+
+  it('applies in-place mutations of a reactive style object', async () => {
+    const style = reactive<Record<string, any>>({ color: 'red' });
+    const { el } = mount({ render: () => h('Label', { style }) });
+
+    style.color = 'blue';
+    await nextTick();
+    expect(el.nativeView.style.color).toBe('blue');
+  });
+
+  it('accepts string styles', () => {
+    const { el } = mount({
+      render: () => h('Label', { style: 'color: red; font-size: 10' }),
+    });
+    expect(el.nativeView.style.color).toBe('red');
+    expect(el.nativeView.style['font-size']).toBe('10');
   });
 });


### PR DESCRIPTION
Stacked on #1130.

## What
`patchStyle` removed every previous property (restoring originals) and then re-set every next property on each render. A `:style` object with N entries meant 2N native CSS writes per update, each re-evaluating the view's CSS state, even when nothing changed. This matters for animated or frequently updated bindings.

Now:
- only properties absent from the next style are removed;
- next is still applied in full (Vue passes the same object as prev and next when a reactive style object is mutated in place), but writes whose value is already applied are skipped.

## Tests
Write counting via a Proxy on the stub's `style`: unchanged `color` is not rewritten, removed `color` is restored once; in-place reactive mutation still applies; string styles still parse. Existing style test unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)