### PR TITLE
ci: stage releases on npm instead of publishing from CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,14 +1,15 @@
 name: Release
 
-# Publishes nativescript-vue and @nativescript-vue/template-blank to npm with
+# Stages nativescript-vue and @nativescript-vue/template-blank on npm with
 # provenance when a v* tag is pushed. Create the tag with `npm run release`.
+# Nothing goes live from CI: a maintainer approves each staged version with
+# 2FA (`npm stage approve`), which is what publishes it.
 #
 # Requires, once, outside this file:
-# - npm Trusted Publishing configured for both packages, pointing at this
-#   repository and this workflow file (npmjs.com → package → Settings →
-#   Trusted Publisher). No npm token is stored anywhere.
-# - A protected `npm` environment in the repository settings with required
-#   reviewers, so a tag push alone cannot publish.
+# - npm Trusted Publishing for both packages, pointing at this repository,
+#   this workflow file and the `npm` environment, with only the
+#   "stage publish" permission. No npm token is stored anywhere.
+# - The `npm` environment in the repository settings.
 
 on:
   push:
@@ -55,13 +56,13 @@ jobs:
       - name: Build
         run: npm run build
 
-  publish:
-    name: Publish to npm
+  stage:
+    name: Stage on npm
     needs: verify
     runs-on: ubuntu-latest
     environment:
       name: npm
-      url: https://www.npmjs.com/package/nativescript-vue
+      url: https://www.npmjs.com/package/nativescript-vue?activeTab=versions
     permissions:
       contents: write # create the GitHub release
       id-token: write # OIDC token for npm trusted publishing + provenance
@@ -97,19 +98,40 @@ jobs:
             echo "dist_tag=latest" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Publish nativescript-vue
-        run: npm publish --provenance --access public --tag "${{ steps.tag.outputs.dist_tag }}"
+      - name: Stage nativescript-vue
+        run: npm stage publish --provenance --access public --tag "${{ steps.tag.outputs.dist_tag }}"
 
-      - name: Publish @nativescript-vue/template-blank
-        run: npm publish --provenance --access public --tag "${{ steps.tag.outputs.dist_tag }}"
+      - name: Stage @nativescript-vue/template-blank
+        run: npm stage publish --provenance --access public --tag "${{ steps.tag.outputs.dist_tag }}"
         working-directory: packages/template-blank
 
-      - name: Create GitHub release
+      # Draft until the staged versions are approved, so the GitHub release
+      # never points at a version that is not installable yet.
+      - name: Create draft GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          args=(--generate-notes --verify-tag)
+          args=(--draft --generate-notes --verify-tag)
           if [[ "$GITHUB_REF_NAME" == *-* ]]; then
             args+=(--prerelease)
           fi
           gh release create "$GITHUB_REF_NAME" "${args[@]}"
+
+      - name: Next steps
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          {
+            echo "## Staged, not published"
+            echo
+            echo "Both packages are staged on npm as \`$version\` with dist-tag \`${{ steps.tag.outputs.dist_tag }}\`."
+            echo "To publish, approve each with 2FA from a machine where you are logged in to npm:"
+            echo
+            echo '```sh'
+            echo "npm stage list nativescript-vue"
+            echo "npm stage approve <stage-id>"
+            echo "npm stage list @nativescript-vue/template-blank"
+            echo "npm stage approve <stage-id>"
+            echo '```'
+            echo
+            echo "Then publish the draft GitHub release for \`$GITHUB_REF_NAME\`."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,8 +17,9 @@ a commit-msg hook enforces it.
 
 ## Releasing
 
-Releases are published by GitHub Actions with npm provenance when a `v*` tag
-is pushed. Nothing publishes from a laptop.
+Releases are staged on npm by GitHub Actions with provenance when a `v*` tag
+is pushed, and go live only after a maintainer approves them with 2FA.
+No token can publish, from CI or from a laptop.
 
 ```sh
 npm run release -- 3.1.0        # or 3.1.0-beta.1 for a prerelease (npm tag: next)
@@ -27,5 +28,17 @@ git push origin main v3.1.0
 
 The script bumps `nativescript-vue` and `@nativescript-vue/template-blank`
 together, commits `release: 3.1.0` and creates the tag. The Release workflow
-verifies the tag matches the package versions, runs the checks, and then
-publishes from the protected `npm` environment.
+verifies the tag matches the package versions, runs the checks, stages both
+packages from the `npm` environment and creates a draft GitHub release.
+
+To publish what was staged:
+
+```sh
+npm stage list nativescript-vue
+npm stage approve <stage-id>                 # prompts for 2FA
+npm stage list @nativescript-vue/template-blank
+npm stage approve <stage-id>
+```
+
+Then publish the draft GitHub release. Approve the template after the
+runtime, since the template depends on the exact runtime version.


### PR DESCRIPTION
Stacked on #1136. Adjusts the release flow from #1123 to npm's staged publishing, matching the trusted-publisher permission you configured ("npm stage publish" only).

## What
- The tag-triggered job runs `npm stage publish --provenance` for both packages instead of `npm publish`. A trust token limited to stage-publish is rejected by plain `npm publish`, so this is required, and it means nothing goes live from CI: a maintainer approves each staged version with 2FA (`npm stage approve`), which is what publishes it.
- The GitHub release is created as a **draft** so it never points at a version that isn't installable yet.
- The job summary prints the exact `npm stage list` / `npm stage approve` commands for both packages.
- `CONTRIBUTING.md` documents the two-step flow; approve the runtime before the template, since the template pins the exact runtime version.

`npm stage publish` needs npm ≥ 11.19; the job already upgrades npm to latest.

## Still to configure on npmjs.com
- The same trusted publisher (repo, `release.yml`, environment `npm`, stage-publish permission) for `@nativescript-vue/template-blank`; only `nativescript-vue` is set up so far.
- Per package, under package access, "Require two-factor authentication and disallow tokens", which npm recommends now that no token needs publish rights.

🤖 Generated with [Claude Code](https://claude.com/claude-code)